### PR TITLE
[GD-95] feat : EventLogRepository 이벤트 참여 여부 판단용 메서드 추가 및 테스트 엔티티 생성 팩토리 추가

### DIFF
--- a/src/main/java/com/dokev/gold_dduck/event/domain/Event.java
+++ b/src/main/java/com/dokev/gold_dduck/event/domain/Event.java
@@ -24,7 +24,6 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.springframework.util.Assert;
 
 @Getter
 @Entity
@@ -68,9 +67,10 @@ public class Event extends BaseEntity {
     private List<Gift> gifts = new ArrayList<>();
 
     @Builder(builderMethodName = "eventInternalBuilder")
-    private Event(GiftChoiceType giftChoiceType, LocalDateTime startAt, LocalDateTime endAt, UUID code,
-        EventProgressStatus eventProgressStatus, String mainTemplate, Integer maxParticipantCount,
-        Member member) {
+    private Event(
+        GiftChoiceType giftChoiceType, LocalDateTime startAt, LocalDateTime endAt, UUID code,
+        EventProgressStatus eventProgressStatus, String mainTemplate, Integer maxParticipantCount, Member member
+    ) {
         this.giftChoiceType = giftChoiceType;
         this.startAt = startAt;
         this.endAt = endAt;
@@ -81,8 +81,10 @@ public class Event extends BaseEntity {
         this.member = member;
     }
 
-    public static EventBuilder builder(GiftChoiceType giftChoiceType, LocalDateTime startAt, LocalDateTime endAt,
-        EventProgressStatus eventProgressStatus, String mainTemplate, Integer maxParticipantCount, Member member) {
+    public static EventBuilder builder(
+        GiftChoiceType giftChoiceType, LocalDateTime startAt, LocalDateTime endAt,
+        EventProgressStatus eventProgressStatus, String mainTemplate, Integer maxParticipantCount, Member member
+    ) {
         Objects.requireNonNull(giftChoiceType, "이벤트에서 선물 받을 방법을 선택해야 합니다.");
         Objects.requireNonNull(startAt, "이벤트 시작 시간은 notnull이어야 합니다.");
         Objects.requireNonNull(endAt, "이벤트 종료 시간은 notnull이어야 합니다.");
@@ -90,7 +92,9 @@ public class Event extends BaseEntity {
         Objects.requireNonNull(mainTemplate, "이벤트 대표 이미지 타입은 notnull이어야 합니다.");
         Objects.requireNonNull(maxParticipantCount, "이벤트 최대 참가자 수는 notnull이어야 합니다.");
         Objects.requireNonNull(member, "이벤트 생성자는 notnull이어야 합니다.");
+
         return eventInternalBuilder()
+            .code(UUID.randomUUID())
             .giftChoiceType(giftChoiceType)
             .startAt(startAt)
             .endAt(endAt)

--- a/src/main/java/com/dokev/gold_dduck/event/repository/EventLogRepository.java
+++ b/src/main/java/com/dokev/gold_dduck/event/repository/EventLogRepository.java
@@ -2,6 +2,13 @@ package com.dokev.gold_dduck.event.repository;
 
 import com.dokev.gold_dduck.event.domain.EventLog;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface EventLogRepository extends JpaRepository<EventLog, Long> {
+
+    @Query("select case when count(el) > 0 then true else false end"
+        + " from EventLog el"
+        + " where el.event.id = :eventId and el.member.id = :memberId")
+    boolean existsByEventIdAndMemberId(@Param("eventId") Long eventId, @Param("memberId") Long memberId);
 }

--- a/src/main/java/com/dokev/gold_dduck/member/domain/Member.java
+++ b/src/main/java/com/dokev/gold_dduck/member/domain/Member.java
@@ -2,6 +2,7 @@ package com.dokev.gold_dduck.member.domain;
 
 import com.dokev.gold_dduck.common.BaseEntity;
 import com.dokev.gold_dduck.event.domain.Event;
+import lombok.AccessLevel;
 import lombok.Getter;
 
 import javax.persistence.*;
@@ -9,7 +10,9 @@ import javax.validation.constraints.Email;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
+import lombok.NoArgsConstructor;
 
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
 @Entity
 @Table(name = "member")
@@ -38,5 +41,12 @@ public class Member extends BaseEntity {
 
     public Optional<String> getProfileImage() {
         return Optional.ofNullable(profileImage);
+    }
+
+    public Member(String name, String email, String socialId, String profileImage) {
+        this.name = name;
+        this.email = email;
+        this.socialId = socialId;
+        this.profileImage = profileImage;
     }
 }

--- a/src/test/java/com/dokev/gold_dduck/event/repository/EventLogRepositoryTest.java
+++ b/src/test/java/com/dokev/gold_dduck/event/repository/EventLogRepositoryTest.java
@@ -1,0 +1,50 @@
+package com.dokev.gold_dduck.event.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.dokev.gold_dduck.config.JpaAuditingConfiguration;
+import com.dokev.gold_dduck.event.domain.Event;
+import com.dokev.gold_dduck.event.domain.EventLog;
+import com.dokev.gold_dduck.factory.TestEventFactory;
+import com.dokev.gold_dduck.factory.TestMemberFactory;
+import com.dokev.gold_dduck.member.domain.Member;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+import org.springframework.context.annotation.Import;
+
+@Import(JpaAuditingConfiguration.class)
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@DataJpaTest
+class EventLogRepositoryTest {
+
+    @Autowired
+    private TestEntityManager entityManager;
+
+    @Autowired
+    private EventLogRepository sut;
+
+    @Test
+    @DisplayName("Event Id와 Member Id를 조건으로 일치하는 EventLog 검색 - 성공 테스트")
+    void existsByEventIdAndMemberIdSuccessTest() {
+        //given
+        Member member = TestMemberFactory.createTestMember();
+        entityManager.persist(member);
+        Event event = TestEventFactory.builder(member).build();
+        entityManager.persist(event);
+        entityManager.persist(new EventLog(event, member, null, null));
+        //when
+        boolean existed1 = sut.existsByEventIdAndMemberId(event.getId(), member.getId());
+        boolean existed2 = sut.existsByEventIdAndMemberId(-1L, member.getId());
+        boolean existed3 = sut.existsByEventIdAndMemberId(event.getId(), -1L);
+        boolean existed4 = sut.existsByEventIdAndMemberId(-1L, -1L);
+        //then
+        assertThat(existed1).isTrue();
+        assertThat(existed2).isFalse();
+        assertThat(existed3).isFalse();
+        assertThat(existed4).isFalse();
+    }
+}

--- a/src/test/java/com/dokev/gold_dduck/factory/TestEventFactory.java
+++ b/src/test/java/com/dokev/gold_dduck/factory/TestEventFactory.java
@@ -1,0 +1,22 @@
+package com.dokev.gold_dduck.factory;
+
+import com.dokev.gold_dduck.event.domain.Event;
+import com.dokev.gold_dduck.event.domain.Event.EventBuilder;
+import com.dokev.gold_dduck.event.domain.EventProgressStatus;
+import com.dokev.gold_dduck.event.domain.GiftChoiceType;
+import com.dokev.gold_dduck.member.domain.Member;
+import java.time.LocalDateTime;
+
+public class TestEventFactory {
+
+    public static EventBuilder builder(Member member) {
+        return Event.builder(
+            GiftChoiceType.FIFO,
+            LocalDateTime.now(),
+            LocalDateTime.now().plusMinutes(10),
+            EventProgressStatus.RUNNING,
+            "template1",
+            60,
+            member);
+    }
+}

--- a/src/test/java/com/dokev/gold_dduck/factory/TestMemberFactory.java
+++ b/src/test/java/com/dokev/gold_dduck/factory/TestMemberFactory.java
@@ -1,0 +1,10 @@
+package com.dokev.gold_dduck.factory;
+
+import com.dokev.gold_dduck.member.domain.Member;
+
+public class TestMemberFactory {
+
+    public static Member createTestMember() {
+        return new Member("dokev", "dokev@gmail.com", "id123", "http://dokev/image.jpg");
+    }
+}


### PR DESCRIPTION
## 📌 이슈 설명 <!-- 어떤 걸 만들었는지 대략적으로 설명해주세요 -->
[GD-95](https://maenguin.atlassian.net/browse/GD-95)
## ✅ PR 포인트 & 궁금한 점 <!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->
* EventLogRepository에 이벤트 참여 여부 판단용 메서드를 추가하고 관련 테스트 코드를 작성하였습니다.
* 테스트시 편의를 위해 테스트 엔티티 생성 팩토리 클래스를 작성하였습니다.
* Event 엔티티 생성자 부분의 스타일을 조금 변경해보았습니다. (파라미터가 엄청 많을 경우의 스타일 논의도 해보면 좋을 것 같습니다)
* Event 빌더에 UUID를 미리 생성하는 코드를 넣었습니다.
* Member 엔티티의 생성자를 추가했습니다.