### PR TITLE
[GD-108] feat : 선물 받기 선착순 컨트롤러단 구현

### DIFF
--- a/src/main/java/com/dokev/gold_dduck/gift/controller/GiftController.java
+++ b/src/main/java/com/dokev/gold_dduck/gift/controller/GiftController.java
@@ -1,0 +1,28 @@
+package com.dokev.gold_dduck.gift.controller;
+
+import com.dokev.gold_dduck.common.ApiResponse;
+import com.dokev.gold_dduck.gift.dto.GiftFifoChoiceDto;
+import com.dokev.gold_dduck.gift.dto.GiftItemDto;
+import com.dokev.gold_dduck.gift.service.GiftService;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequestMapping("api")
+@RestController
+public class GiftController {
+
+    private final GiftService giftService;
+
+    public GiftController(GiftService giftService) {
+        this.giftService = giftService;
+    }
+
+    @GetMapping("v1/gifts/fifo")
+    public ApiResponse<Object> chooseGiftItemByFIFO(@RequestBody GiftFifoChoiceDto giftFifoChoiceDto) {
+        GiftItemDto giftItemDto = giftService.chooseGiftItemByFIFO(giftFifoChoiceDto.getEventId(),
+            giftFifoChoiceDto.getMemberId(), giftFifoChoiceDto.getGiftId());
+        return ApiResponse.success(giftItemDto);
+    }
+}

--- a/src/main/java/com/dokev/gold_dduck/gift/controller/GiftController.java
+++ b/src/main/java/com/dokev/gold_dduck/gift/controller/GiftController.java
@@ -4,7 +4,7 @@ import com.dokev.gold_dduck.common.ApiResponse;
 import com.dokev.gold_dduck.gift.dto.GiftFifoChoiceDto;
 import com.dokev.gold_dduck.gift.dto.GiftItemDto;
 import com.dokev.gold_dduck.gift.service.GiftService;
-import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -19,8 +19,8 @@ public class GiftController {
         this.giftService = giftService;
     }
 
-    @GetMapping("v1/gifts/fifo")
-    public ApiResponse<Object> chooseGiftItemByFIFO(@RequestBody GiftFifoChoiceDto giftFifoChoiceDto) {
+    @PostMapping("v1/gifts/fifo")
+    public ApiResponse<GiftItemDto> chooseGiftItemByFIFO(@RequestBody GiftFifoChoiceDto giftFifoChoiceDto) {
         GiftItemDto giftItemDto = giftService.chooseGiftItemByFIFO(giftFifoChoiceDto.getEventId(),
             giftFifoChoiceDto.getMemberId(), giftFifoChoiceDto.getGiftId());
         return ApiResponse.success(giftItemDto);

--- a/src/main/java/com/dokev/gold_dduck/gift/dto/GiftFifoChoiceDto.java
+++ b/src/main/java/com/dokev/gold_dduck/gift/dto/GiftFifoChoiceDto.java
@@ -1,0 +1,26 @@
+package com.dokev.gold_dduck.gift.dto;
+
+import javax.validation.constraints.NotNull;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class GiftFifoChoiceDto {
+
+    @NotNull
+    private Long eventId;
+
+    @NotNull
+    private Long memberId;
+
+    @NotNull
+    private Long giftId;
+
+    public GiftFifoChoiceDto(Long eventId, Long memberId, Long giftId) {
+        this.eventId = eventId;
+        this.memberId = memberId;
+        this.giftId = giftId;
+    }
+}

--- a/src/test/java/com/dokev/gold_dduck/gift/controller/GiftControllerTest.java
+++ b/src/test/java/com/dokev/gold_dduck/gift/controller/GiftControllerTest.java
@@ -65,7 +65,7 @@ class GiftControllerTest {
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(objectMapper.writeValueAsString(giftFifoChoiceDto))
         );
-        //given
+        //then
         result.andDo(print())
             .andExpectAll(
                 status().isOk(),
@@ -92,7 +92,7 @@ class GiftControllerTest {
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(objectMapper.writeValueAsString(giftFifoChoiceDto))
         );
-        //given
+        //then
         result.andDo(print())
             .andExpectAll(
                 status().isBadRequest(),
@@ -118,7 +118,7 @@ class GiftControllerTest {
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(objectMapper.writeValueAsString(giftFifoChoiceDto))
         );
-        //given
+        //then
         result.andDo(print())
             .andExpectAll(
                 status().isBadRequest(),
@@ -146,7 +146,7 @@ class GiftControllerTest {
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(objectMapper.writeValueAsString(giftFifoChoiceDto))
         );
-        //given
+        //then
         result.andDo(print())
             .andExpectAll(
                 status().isBadRequest(),
@@ -173,7 +173,7 @@ class GiftControllerTest {
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(objectMapper.writeValueAsString(giftFifoChoiceDto))
         );
-        //given
+        //then
         result.andDo(print())
             .andExpectAll(
                 status().isBadRequest(),
@@ -201,7 +201,7 @@ class GiftControllerTest {
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(objectMapper.writeValueAsString(giftFifoChoiceDto))
         );
-        //given
+        //then
         result.andDo(print())
             .andExpectAll(
                 status().isBadRequest(),

--- a/src/test/java/com/dokev/gold_dduck/gift/controller/GiftControllerTest.java
+++ b/src/test/java/com/dokev/gold_dduck/gift/controller/GiftControllerTest.java
@@ -3,7 +3,7 @@ package com.dokev.gold_dduck.gift.controller;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.handler;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -60,7 +60,7 @@ class GiftControllerTest {
         GiftItem firstGiftItem = chosenGift.getGiftItems().get(0);
         //when
         ResultActions result = mockMvc.perform(
-            get("/api/v1/gifts/fifo")
+            post("/api/v1/gifts/fifo")
                 .accept(MediaType.APPLICATION_JSON)
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(objectMapper.writeValueAsString(giftFifoChoiceDto))
@@ -87,7 +87,7 @@ class GiftControllerTest {
         GiftFifoChoiceDto giftFifoChoiceDto = new GiftFifoChoiceDto(invalidEventId, 1L, 1L);
         //when
         ResultActions result = mockMvc.perform(
-            get("/api/v1/gifts/fifo")
+            post("/api/v1/gifts/fifo")
                 .accept(MediaType.APPLICATION_JSON)
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(objectMapper.writeValueAsString(giftFifoChoiceDto))
@@ -113,7 +113,7 @@ class GiftControllerTest {
         GiftFifoChoiceDto giftFifoChoiceDto = new GiftFifoChoiceDto(givenEvent.getId(), invalidMemberId, 1L);
         //when
         ResultActions result = mockMvc.perform(
-            get("/api/v1/gifts/fifo")
+            post("/api/v1/gifts/fifo")
                 .accept(MediaType.APPLICATION_JSON)
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(objectMapper.writeValueAsString(giftFifoChoiceDto))
@@ -141,7 +141,7 @@ class GiftControllerTest {
         giftService.chooseGiftItemByFIFO(givenEvent.getId(), givenEvent.getMember().getId(), chosenGift.getId());
         //when
         ResultActions result = mockMvc.perform(
-            get("/api/v1/gifts/fifo")
+            post("/api/v1/gifts/fifo")
                 .accept(MediaType.APPLICATION_JSON)
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(objectMapper.writeValueAsString(giftFifoChoiceDto))
@@ -168,7 +168,7 @@ class GiftControllerTest {
             invalidGiftId);
         //when
         ResultActions result = mockMvc.perform(
-            get("/api/v1/gifts/fifo")
+            post("/api/v1/gifts/fifo")
                 .accept(MediaType.APPLICATION_JSON)
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(objectMapper.writeValueAsString(giftFifoChoiceDto))
@@ -196,7 +196,7 @@ class GiftControllerTest {
             gift.getId());
         //when
         ResultActions result = mockMvc.perform(
-            get("/api/v1/gifts/fifo")
+            post("/api/v1/gifts/fifo")
                 .accept(MediaType.APPLICATION_JSON)
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(objectMapper.writeValueAsString(giftFifoChoiceDto))

--- a/src/test/java/com/dokev/gold_dduck/gift/controller/GiftControllerTest.java
+++ b/src/test/java/com/dokev/gold_dduck/gift/controller/GiftControllerTest.java
@@ -1,0 +1,248 @@
+package com.dokev.gold_dduck.gift.controller;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.handler;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.dokev.gold_dduck.common.error.ErrorCode;
+import com.dokev.gold_dduck.event.domain.Event;
+import com.dokev.gold_dduck.factory.TestEventFactory;
+import com.dokev.gold_dduck.factory.TestGiftFactory;
+import com.dokev.gold_dduck.factory.TestGiftItemFactory;
+import com.dokev.gold_dduck.factory.TestMemberFactory;
+import com.dokev.gold_dduck.gift.domain.Gift;
+import com.dokev.gold_dduck.gift.domain.GiftItem;
+import com.dokev.gold_dduck.gift.dto.GiftFifoChoiceDto;
+import com.dokev.gold_dduck.gift.service.GiftService;
+import com.dokev.gold_dduck.member.domain.Member;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import javax.persistence.EntityManager;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.transaction.annotation.Transactional;
+
+@Transactional
+@AutoConfigureMockMvc
+@SpringBootTest
+class GiftControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private EntityManager entityManager;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Autowired
+    private GiftService giftService;
+
+    @Test
+    @DisplayName("선착순으로 선물 받기 성공 테스트")
+    void chooseGiftItemByFIFOSuccessTest() throws Exception {
+        //given
+        Event givenEvent = givenCompleteEvent();
+        Gift chosenGift = givenEvent.getGifts().get(0);
+        GiftFifoChoiceDto giftFifoChoiceDto = new GiftFifoChoiceDto(givenEvent.getId(), givenEvent.getMember().getId(),
+            chosenGift.getId());
+        GiftItem firstGiftItem = chosenGift.getGiftItems().get(0);
+        //when
+        ResultActions result = mockMvc.perform(
+            get("/api/v1/gifts/fifo")
+                .accept(MediaType.APPLICATION_JSON)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(giftFifoChoiceDto))
+        );
+        //given
+        result.andDo(print())
+            .andExpectAll(
+                status().isOk(),
+                handler().handlerType(GiftController.class),
+                handler().methodName("chooseGiftItemByFIFO"),
+                jsonPath("$.success", is(true)),
+                jsonPath("$.error", is(nullValue())),
+                jsonPath("$.data.id", is(firstGiftItem.getId().intValue())),
+                jsonPath("$.data.giftType", is(firstGiftItem.getGiftType().toString())),
+                jsonPath("$.data.content", is(firstGiftItem.getContent()))
+            );
+    }
+
+    @Test
+    @DisplayName("선착순으로 선물 받기 실패 테스트 (잘못된 eventId)")
+    void chooseGiftItemByFIFOFailureTest() throws Exception {
+        //given
+        Long invalidEventId = 1L;
+        GiftFifoChoiceDto giftFifoChoiceDto = new GiftFifoChoiceDto(invalidEventId, 1L, 1L);
+        //when
+        ResultActions result = mockMvc.perform(
+            get("/api/v1/gifts/fifo")
+                .accept(MediaType.APPLICATION_JSON)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(giftFifoChoiceDto))
+        );
+        //given
+        result.andDo(print())
+            .andExpectAll(
+                status().isBadRequest(),
+                handler().handlerType(GiftController.class),
+                handler().methodName("chooseGiftItemByFIFO"),
+                jsonPath("$.success", is(false)),
+                jsonPath("$.error.code", is(ErrorCode.ENTITY_NOT_FOUND.getCode())),
+                jsonPath("$.error.message", containsString(Event.class.getName()))
+            );
+    }
+
+    @Test
+    @DisplayName("선착순으로 선물 받기 실패 테스트 (잘못된 memberId)")
+    void chooseGiftItemByFIFOFailureTest2() throws Exception {
+        //given
+        Event givenEvent = givenEvent();
+        Long invalidMemberId = -1L;
+        GiftFifoChoiceDto giftFifoChoiceDto = new GiftFifoChoiceDto(givenEvent.getId(), invalidMemberId, 1L);
+        //when
+        ResultActions result = mockMvc.perform(
+            get("/api/v1/gifts/fifo")
+                .accept(MediaType.APPLICATION_JSON)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(giftFifoChoiceDto))
+        );
+        //given
+        result.andDo(print())
+            .andExpectAll(
+                status().isBadRequest(),
+                handler().handlerType(GiftController.class),
+                handler().methodName("chooseGiftItemByFIFO"),
+                jsonPath("$.success", is(false)),
+                jsonPath("$.error.code", is(ErrorCode.ENTITY_NOT_FOUND.getCode())),
+                jsonPath("$.error.message", containsString(Member.class.getName()))
+            );
+    }
+
+    @Test
+    @DisplayName("선착순으로 선물 받기 실패 테스트 (이미 이벤트에 참여한 멤버)")
+    void chooseGiftItemByFIFOFailureTest3() throws Exception {
+        //given
+        Event givenEvent = givenCompleteEvent();
+        Gift chosenGift = givenEvent.getGifts().get(0);
+        GiftFifoChoiceDto giftFifoChoiceDto = new GiftFifoChoiceDto(givenEvent.getId(), givenEvent.getMember().getId(),
+            chosenGift.getId());
+        giftService.chooseGiftItemByFIFO(givenEvent.getId(), givenEvent.getMember().getId(), chosenGift.getId());
+        //when
+        ResultActions result = mockMvc.perform(
+            get("/api/v1/gifts/fifo")
+                .accept(MediaType.APPLICATION_JSON)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(giftFifoChoiceDto))
+        );
+        //given
+        result.andDo(print())
+            .andExpectAll(
+                status().isBadRequest(),
+                handler().handlerType(GiftController.class),
+                handler().methodName("chooseGiftItemByFIFO"),
+                jsonPath("$.success", is(false)),
+                jsonPath("$.error.code", is(ErrorCode.EVENT_ALREADY_PARTICIPATED.getCode())),
+                jsonPath("$.error.message", containsString(ErrorCode.EVENT_ALREADY_PARTICIPATED.getMessage()))
+            );
+    }
+
+    @Test
+    @DisplayName("선착순으로 선물 받기 실패 테스트 (잘못된 giftId)")
+    void chooseGiftItemByFIFOFailureTest4() throws Exception {
+        //given
+        Event givenEvent = givenEvent();
+        Long invalidGiftId = -1L;
+        GiftFifoChoiceDto giftFifoChoiceDto = new GiftFifoChoiceDto(givenEvent.getId(), givenEvent.getMember().getId(),
+            invalidGiftId);
+        //when
+        ResultActions result = mockMvc.perform(
+            get("/api/v1/gifts/fifo")
+                .accept(MediaType.APPLICATION_JSON)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(giftFifoChoiceDto))
+        );
+        //given
+        result.andDo(print())
+            .andExpectAll(
+                status().isBadRequest(),
+                handler().handlerType(GiftController.class),
+                handler().methodName("chooseGiftItemByFIFO"),
+                jsonPath("$.success", is(false)),
+                jsonPath("$.error.code", is(ErrorCode.ENTITY_NOT_FOUND.getCode())),
+                jsonPath("$.error.message", containsString(Gift.class.getName()))
+            );
+    }
+
+    @Test
+    @DisplayName("선착순으로 선물 받기 실패 테스트 (선물 재고 부족)")
+    void chooseGiftItemByFIFOFailureTest5() throws Exception {
+        //given
+        Event givenEvent = givenEvent();
+        Gift gift = givenGift(givenEvent);
+        GiftItem giftItem = givenGiftItem(gift, givenEvent.getMember());
+        GiftFifoChoiceDto giftFifoChoiceDto = new GiftFifoChoiceDto(givenEvent.getId(), givenEvent.getMember().getId(),
+            gift.getId());
+        //when
+        ResultActions result = mockMvc.perform(
+            get("/api/v1/gifts/fifo")
+                .accept(MediaType.APPLICATION_JSON)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(giftFifoChoiceDto))
+        );
+        //given
+        result.andDo(print())
+            .andExpectAll(
+                status().isBadRequest(),
+                handler().handlerType(GiftController.class),
+                handler().methodName("chooseGiftItemByFIFO"),
+                jsonPath("$.success", is(false)),
+                jsonPath("$.error.code", is(ErrorCode.GIFT_STOCK_OUT.getCode())),
+                jsonPath("$.error.message", containsString(ErrorCode.GIFT_STOCK_OUT.getMessage()))
+            );
+    }
+
+    private Event givenCompleteEvent() {
+        Member member = givenMember();
+        Event event = TestEventFactory.createEvent(member);
+        entityManager.persist(event);
+        return event;
+    }
+
+    private Event givenEvent() {
+        Member member = givenMember();
+        Event event = TestEventFactory.builder(member).build();
+        entityManager.persist(event);
+        return event;
+    }
+
+    private Member givenMember() {
+        Member member = TestMemberFactory.createTestMember();
+        entityManager.persist(member);
+        return member;
+    }
+
+    private Gift givenGift(Event event) {
+        Gift gift = TestGiftFactory.createTestGift("커피", 0, event);
+        entityManager.persist(gift);
+        return gift;
+    }
+
+    private GiftItem givenGiftItem(Gift gift, Member member) {
+        GiftItem giftItem = TestGiftItemFactory.createTestGiftItem("스타벅스 커피1", gift);
+        giftItem.allocateMember(member);
+        entityManager.persist(giftItem);
+        return giftItem;
+    }
+}


### PR DESCRIPTION
## 📌 이슈 설명 <!-- 어떤 걸 만들었는지 대략적으로 설명해주세요 -->
[GD-108](https://maenguin.atlassian.net/browse/GD-108)
## ✅ PR 포인트 & 궁금한 점 <!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->
**선물 받기 선착순 컨트롤러단 구현**
* 선착순 선물받기 API를 추가하고 관련 테스트를 추가했습니다.

* API 경로를 PATCH /events/{eventId}/gifts/{giftId}/fifo 하려다
랜덤이랑 깔맞춤하기 위해서 /gifts/fifo로 했습니다. 
(랜덤은 /gifts/random으로 하려고 합니다. 의견 받습니다 경로짓기 어렵네요..)

* PATCH가 맞는지.. 내부에서 엔티티를 추가하니깐 POST가 맞는지 고민하다가
답이 안나와서 일단 GET으로 했습니다 (최초 요청 이후 멱등성이 보장된다고 생각했습니다)
