### PR TITLE
[GD-121] 카카오 로그인 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -38,6 +38,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
     implementation group: 'org.apache.commons', name: 'commons-lang3', version: '3.12.0'
     implementation 'io.springfox:springfox-boot-starter:3.0.0'
+    testImplementation 'org.springframework.security:spring-security-test'
 }
 
 test {

--- a/build.gradle
+++ b/build.gradle
@@ -36,6 +36,7 @@ dependencies {
     implementation 'com.auth0:java-jwt:3.18.1'
     implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
+    implementation group: 'org.apache.commons', name: 'commons-lang3', version: '3.12.0'
 }
 
 test {

--- a/build.gradle
+++ b/build.gradle
@@ -33,6 +33,9 @@ dependencies {
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.restdocs:spring-restdocs-mockmvc'
+    implementation 'com.auth0:java-jwt:3.18.1'
+    implementation 'org.springframework.boot:spring-boot-starter-security'
+    implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
 }
 
 test {

--- a/src/main/java/com/dokev/gold_dduck/common/util/CookieUtil.java
+++ b/src/main/java/com/dokev/gold_dduck/common/util/CookieUtil.java
@@ -1,0 +1,62 @@
+package com.dokev.gold_dduck.common.util;
+
+import java.util.Base64;
+import java.util.Optional;
+import javax.servlet.http.Cookie;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import org.springframework.util.SerializationUtils;
+
+public class CookieUtil {
+
+    public static Optional<Cookie> getCookie(HttpServletRequest request, String name) {
+        Cookie[] cookies = request.getCookies();
+
+        if (cookies != null && cookies.length > 0) {
+            for (Cookie cookie : cookies) {
+                if (name.equals(cookie.getName())) {
+                    return Optional.of(cookie);
+                }
+            }
+        }
+        return Optional.empty();
+    }
+
+    public static void addCookie(HttpServletResponse response, String name, String value, int maxAge) {
+        Cookie cookie = new Cookie(name, value);
+        cookie.setPath("/");
+        cookie.setHttpOnly(true);
+        cookie.setMaxAge(maxAge);
+
+        response.addCookie(cookie);
+    }
+
+    public static void deleteCookie(HttpServletRequest request, HttpServletResponse response, String name) {
+        Cookie[] cookies = request.getCookies();
+
+        if (cookies != null && cookies.length > 0) {
+            for (Cookie cookie : cookies) {
+                if (name.equals(cookie.getName())) {
+                    cookie.setValue("");
+                    cookie.setPath("/");
+                    cookie.setMaxAge(0);
+                    response.addCookie(cookie);
+                }
+            }
+        }
+    }
+
+    public static String serialize(Object obj) {
+        return Base64.getUrlEncoder()
+            .encodeToString(SerializationUtils.serialize(obj));
+    }
+
+    public static <T> T deserialize(Cookie cookie, Class<T> cls) {
+        return cls.cast(
+            SerializationUtils.deserialize(
+                Base64.getUrlDecoder().decode(cookie.getValue())
+            )
+        );
+    }
+
+}

--- a/src/main/java/com/dokev/gold_dduck/config/WebSecurityConfiguration.java
+++ b/src/main/java/com/dokev/gold_dduck/config/WebSecurityConfiguration.java
@@ -1,0 +1,86 @@
+package com.dokev.gold_dduck.config;
+
+import com.dokev.gold_dduck.jwt.Jwt;
+import com.dokev.gold_dduck.jwt.JwtAuthenticationFilter;
+import com.dokev.gold_dduck.jwt.JwtProperties;
+import com.dokev.gold_dduck.member.service.MemberService;
+import com.dokev.gold_dduck.oauth2.HttpCookieOAuth2AuthorizationRequestRepository;
+import com.dokev.gold_dduck.oauth2.OAuth2AuthenticationSuccessHandler;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.builders.WebSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.oauth2.client.web.AuthorizationRequestRepository;
+import org.springframework.security.oauth2.core.endpoint.OAuth2AuthorizationRequest;
+import org.springframework.security.web.context.SecurityContextPersistenceFilter;
+
+@EnableWebSecurity
+@Configuration
+public class WebSecurityConfiguration extends WebSecurityConfigurerAdapter {
+
+    private final JwtProperties jwtProperties;
+
+    private final MemberService memberService;
+
+    public WebSecurityConfiguration(JwtProperties jwtProperties, MemberService memberService) {
+        this.jwtProperties = jwtProperties;
+        this.memberService = memberService;
+    }
+
+    @Bean
+    public Jwt jwt() {
+        return new Jwt(
+            jwtProperties.getIssuer(),
+            jwtProperties.getClientSecret(),
+            jwtProperties.getExpirySeconds()
+        );
+    }
+
+    public JwtAuthenticationFilter jwtAuthenticationFilter() {
+        Jwt jwt = getApplicationContext().getBean(Jwt.class);
+        return new JwtAuthenticationFilter(jwtProperties.getHeader(), jwt);
+    }
+
+    @Bean
+    public OAuth2AuthenticationSuccessHandler oAuth2AuthenticationSuccessHandler() {
+        Jwt jwt = getApplicationContext().getBean(Jwt.class);
+        return new OAuth2AuthenticationSuccessHandler(jwt, memberService);
+    }
+
+    @Bean
+    public AuthorizationRequestRepository<OAuth2AuthorizationRequest> authorizationRequestRepository() {
+        return new HttpCookieOAuth2AuthorizationRequestRepository();
+    }
+
+    @Override
+    public void configure(WebSecurity web) throws Exception {
+        web.ignoring().antMatchers("/h2-console/**", "login/**");
+    }
+
+    @Override
+    protected void configure(HttpSecurity http) throws Exception {
+        http.authorizeRequests()
+            .antMatchers("/api/user/me").hasAnyRole("USER", "ADMIN")
+            .anyRequest().permitAll()
+            .and()
+            .csrf().disable()
+            .headers().disable()
+            .httpBasic().disable()
+            .rememberMe().disable()
+            .logout().disable()
+            .sessionManagement().sessionCreationPolicy(SessionCreationPolicy.STATELESS)
+            .and()
+            .oauth2Login()
+            .authorizationEndpoint()
+            .baseUri("/oauth2/authorization")
+            .authorizationRequestRepository(authorizationRequestRepository())
+            .and()
+            .successHandler(oAuth2AuthenticationSuccessHandler())
+            .and()
+            .addFilterAfter(jwtAuthenticationFilter(), SecurityContextPersistenceFilter.class);
+
+    }
+}

--- a/src/main/java/com/dokev/gold_dduck/config/WebSecurityConfiguration.java
+++ b/src/main/java/com/dokev/gold_dduck/config/WebSecurityConfiguration.java
@@ -78,7 +78,13 @@ public class WebSecurityConfiguration extends WebSecurityConfigurerAdapter {
 
     @Override
     public void configure(WebSecurity web) throws Exception {
-        web.ignoring().antMatchers("/h2-console/**", "login/**");
+        web.ignoring().antMatchers(
+            "/h2-console/**",
+            "/swagger-ui/**",
+            "/v3/api-docs/**",
+            "/swagger-ui/**",
+            "/swagger-resources/**",
+            "/swagger-resources");
     }
 
     @Override

--- a/src/main/java/com/dokev/gold_dduck/jwt/Jwt.java
+++ b/src/main/java/com/dokev/gold_dduck/jwt/Jwt.java
@@ -1,0 +1,103 @@
+package com.dokev.gold_dduck.jwt;
+
+import com.auth0.jwt.JWTCreator;
+import com.auth0.jwt.JWTVerifier;
+import com.auth0.jwt.algorithms.Algorithm;
+import com.auth0.jwt.interfaces.Claim;
+import com.auth0.jwt.interfaces.DecodedJWT;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+public class Jwt {
+
+    private final String issuer;
+
+    private final String clientSecret;
+
+    private final int expirySeconds;
+
+    private final Algorithm algorithm;
+
+    private final JWTVerifier jwtVerifier;
+
+    public Jwt(String issuer, String clientSecret, int expirySeconds) {
+        this.issuer = issuer;
+        this.clientSecret = clientSecret;
+        this.expirySeconds = expirySeconds;
+        this.algorithm = Algorithm.HMAC512(clientSecret);
+        this.jwtVerifier = com.auth0.jwt.JWT.require(algorithm)
+            .withIssuer(issuer)
+            .build();
+    }
+
+    public String sign(Claims claims) {
+        Date now = new Date();
+        JWTCreator.Builder builder = com.auth0.jwt.JWT.create();
+        builder.withIssuer(issuer)
+            .withIssuedAt(now)
+            .withClaim("username", claims.username)
+            .withArrayClaim("roles", claims.roles);
+        if (expirySeconds > 0) {
+            builder.withExpiresAt(new Date(now.getTime() + expirySeconds * 1_000L));
+        }
+        return builder.sign(algorithm);
+    }
+
+    public Claims verify(String token) {
+        return new Claims(jwtVerifier.verify(token));
+    }
+
+    @ToString(of = {"username", "roles", "iat", "exp"})
+    @NoArgsConstructor(access = AccessLevel.PRIVATE)
+    static public class Claims {
+
+        String username;
+
+        String[] roles;
+
+        Date iat;
+
+        Date exp;
+
+        Claims(DecodedJWT decodedJWT) {
+            Claim username = decodedJWT.getClaim("username");
+            if (!username.isNull()) {
+                this.username = username.asString();
+            }
+            Claim roles = decodedJWT.getClaim("roles");
+            if (!roles.isNull()) {
+                this.roles = roles.asArray(String.class);
+            }
+            this.iat = decodedJWT.getIssuedAt();
+            this.exp = decodedJWT.getExpiresAt();
+        }
+
+        public static Claims from(String username, String[] roles) {
+            Claims claims = new Claims();
+            claims.username = username;
+            claims.roles = roles;
+            return claims;
+        }
+
+        public Map<String, Object> asMap() {
+            HashMap<String, Object> map = new HashMap<>();
+            map.put("username", username);
+            map.put("roles", roles);
+            map.put("iat", iat());
+            map.put("exp", exp());
+            return map;
+        }
+
+        public long iat() {
+            return iat != null ? iat.getTime() : -1;
+        }
+
+        public long exp() {
+            return exp != null ? exp.getTime() : -1;
+        }
+    }
+}

--- a/src/main/java/com/dokev/gold_dduck/jwt/Jwt.java
+++ b/src/main/java/com/dokev/gold_dduck/jwt/Jwt.java
@@ -52,7 +52,7 @@ public class Jwt {
         return new Claims(jwtVerifier.verify(token));
     }
 
-    @ToString(of = {"id", "username", "roles", "iat", "exp"})
+    @ToString(of = {"userId", "username", "roles", "iat", "exp"})
     @NoArgsConstructor(access = AccessLevel.PRIVATE)
     static public class Claims {
 

--- a/src/main/java/com/dokev/gold_dduck/jwt/Jwt.java
+++ b/src/main/java/com/dokev/gold_dduck/jwt/Jwt.java
@@ -39,6 +39,7 @@ public class Jwt {
         JWTCreator.Builder builder = com.auth0.jwt.JWT.create();
         builder.withIssuer(issuer)
             .withIssuedAt(now)
+            .withClaim("userId", claims.userId)
             .withClaim("username", claims.username)
             .withArrayClaim("roles", claims.roles);
         if (expirySeconds > 0) {
@@ -51,9 +52,11 @@ public class Jwt {
         return new Claims(jwtVerifier.verify(token));
     }
 
-    @ToString(of = {"username", "roles", "iat", "exp"})
+    @ToString(of = {"id", "username", "roles", "iat", "exp"})
     @NoArgsConstructor(access = AccessLevel.PRIVATE)
     static public class Claims {
+
+        Long userId;
 
         String username;
 
@@ -64,6 +67,10 @@ public class Jwt {
         Date exp;
 
         Claims(DecodedJWT decodedJWT) {
+            Claim userId = decodedJWT.getClaim("userId");
+            if (!userId.isNull()) {
+                this.userId = userId.asLong();
+            }
             Claim username = decodedJWT.getClaim("username");
             if (!username.isNull()) {
                 this.username = username.asString();
@@ -76,8 +83,9 @@ public class Jwt {
             this.exp = decodedJWT.getExpiresAt();
         }
 
-        public static Claims from(String username, String[] roles) {
+        public static Claims of(Long userId, String username, String[] roles) {
             Claims claims = new Claims();
+            claims.userId = userId;
             claims.username = username;
             claims.roles = roles;
             return claims;
@@ -85,6 +93,7 @@ public class Jwt {
 
         public Map<String, Object> asMap() {
             HashMap<String, Object> map = new HashMap<>();
+            map.put("userId", userId);
             map.put("username", username);
             map.put("roles", roles);
             map.put("iat", iat());

--- a/src/main/java/com/dokev/gold_dduck/jwt/JwtAuthentication.java
+++ b/src/main/java/com/dokev/gold_dduck/jwt/JwtAuthentication.java
@@ -2,30 +2,22 @@ package com.dokev.gold_dduck.jwt;
 
 import static org.apache.commons.lang3.StringUtils.isNotEmpty;
 
-import org.apache.commons.lang3.builder.ToStringBuilder;
-import org.apache.commons.lang3.builder.ToStringStyle;
+import lombok.ToString;
 import org.springframework.util.Assert;
 
+@ToString(of = {"userId", "username"})
 public class JwtAuthentication {
 
-    public final String token;
+    public final Long userId;
 
     public final String username;
 
 
-    public JwtAuthentication(String token, String username) {
-        Assert.isTrue(isNotEmpty(token), "token must be provided.");
+    public JwtAuthentication(Long userId, String username) {
+        Assert.notNull(userId, "userId must be provided.");
         Assert.isTrue(isNotEmpty(username), "username must be provided.");
 
-        this.token = token;
+        this.userId = userId;
         this.username = username;
-    }
-
-    @Override
-    public String toString() {
-        return new ToStringBuilder(this, ToStringStyle.SHORT_PREFIX_STYLE)
-            .append("token", token)
-            .append("username", username)
-            .toString();
     }
 }

--- a/src/main/java/com/dokev/gold_dduck/jwt/JwtAuthentication.java
+++ b/src/main/java/com/dokev/gold_dduck/jwt/JwtAuthentication.java
@@ -1,0 +1,31 @@
+package com.dokev.gold_dduck.jwt;
+
+import static org.apache.commons.lang3.StringUtils.isNotEmpty;
+
+import org.apache.commons.lang3.builder.ToStringBuilder;
+import org.apache.commons.lang3.builder.ToStringStyle;
+import org.springframework.util.Assert;
+
+public class JwtAuthentication {
+
+    public final String token;
+
+    public final String username;
+
+
+    public JwtAuthentication(String token, String username) {
+        Assert.isTrue(isNotEmpty(token), "token must be provided.");
+        Assert.isTrue(isNotEmpty(username), "username must be provided.");
+
+        this.token = token;
+        this.username = username;
+    }
+
+    @Override
+    public String toString() {
+        return new ToStringBuilder(this, ToStringStyle.SHORT_PREFIX_STYLE)
+            .append("token", token)
+            .append("username", username)
+            .toString();
+    }
+}

--- a/src/main/java/com/dokev/gold_dduck/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/dokev/gold_dduck/jwt/JwtAuthenticationFilter.java
@@ -1,0 +1,94 @@
+package com.dokev.gold_dduck.jwt;
+
+import com.dokev.gold_dduck.jwt.Jwt.Claims;
+import java.io.IOException;
+import java.net.URLDecoder;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
+import org.springframework.web.filter.GenericFilterBean;
+
+@Slf4j
+public class JwtAuthenticationFilter extends GenericFilterBean {
+
+    private final String headerKey;
+
+    private final Jwt jwt;
+
+    public JwtAuthenticationFilter(String headerKey, Jwt jwt) {
+        this.headerKey = headerKey;
+        this.jwt = jwt;
+    }
+
+    @Override
+    public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain)
+        throws IOException, ServletException {
+
+        HttpServletRequest req = (HttpServletRequest) request;
+        HttpServletResponse res = (HttpServletResponse) response;
+
+        if (SecurityContextHolder.getContext().getAuthentication() == null) {
+            String token = getToken(req);
+            if (token != null) {
+                try {
+                    Claims claims = verify(token);
+                    log.debug("Jwt parse result: {}", claims);
+
+                    String username = claims.username;
+                    List<GrantedAuthority> authorities = getAuthorities(claims);
+
+                    if (username != null && !username.isEmpty() && authorities.size() > 0) {
+                        UsernamePasswordAuthenticationToken authentication
+                            = new UsernamePasswordAuthenticationToken(username, null, authorities);
+                        authentication.setDetails(new WebAuthenticationDetailsSource().buildDetails(req));
+                        SecurityContextHolder.getContext().setAuthentication(authentication);
+                    }
+                } catch (Exception e) {
+                    log.warn("Jwt processing filed: {}", e.getMessage());
+                }
+            }
+        } else {
+            log.debug("SecurityContextHolder not populated with security token, as it already contained: {}",
+                SecurityContextHolder.getContext().getAuthentication());
+        }
+
+        chain.doFilter(req, res);
+    }
+
+    private String getToken(HttpServletRequest request) {
+        String token = request.getHeader(headerKey);
+        if (token != null && !token.isEmpty()) {
+            log.debug("Jwt token detected : {}", token);
+            try {
+                return URLDecoder.decode(token, "UTF-8");
+            } catch (Exception e) {
+                logger.error(e.getMessage(), e);
+            }
+        }
+        return null;
+    }
+
+    private Jwt.Claims verify(String token) {
+        return jwt.verify(token);
+    }
+
+    private List<GrantedAuthority> getAuthorities(Claims claims) {
+        String[] roles = claims.roles;
+        return roles == null || roles.length == 0
+            ? Collections.emptyList()
+            : Arrays.stream(roles).map(SimpleGrantedAuthority::new).collect(Collectors.toList());
+    }
+}

--- a/src/main/java/com/dokev/gold_dduck/jwt/JwtAuthenticationToken.java
+++ b/src/main/java/com/dokev/gold_dduck/jwt/JwtAuthenticationToken.java
@@ -1,0 +1,65 @@
+package com.dokev.gold_dduck.jwt;
+
+import java.util.Collection;
+import org.apache.commons.lang3.builder.ToStringBuilder;
+import org.apache.commons.lang3.builder.ToStringStyle;
+import org.springframework.security.authentication.AbstractAuthenticationToken;
+import org.springframework.security.core.GrantedAuthority;
+
+public class JwtAuthenticationToken extends AbstractAuthenticationToken {
+
+    private final Object principal;
+
+    private String credentials;
+
+    public JwtAuthenticationToken(String principal, String credentials) {
+        super(null);
+        super.setAuthenticated(false);
+
+        this.principal = principal;
+        this.credentials = credentials;
+    }
+
+    public JwtAuthenticationToken(
+        Collection<? extends GrantedAuthority> authorities,
+        Object principal, String credentials
+    ) {
+        super(authorities);
+        super.setAuthenticated(true);
+
+        this.principal = principal;
+        this.credentials = credentials;
+    }
+
+    @Override
+    public Object getCredentials() {
+        return credentials;
+    }
+
+    @Override
+    public Object getPrincipal() {
+        return principal;
+    }
+
+    @Override
+    public void setAuthenticated(boolean authenticated) {
+        if (authenticated) {
+            throw new IllegalArgumentException("Cannot set this token to trusted.");
+        }
+        super.setAuthenticated(false);
+    }
+
+    @Override
+    public void eraseCredentials() {
+        super.eraseCredentials();
+        this.credentials = null;
+    }
+
+    @Override
+    public String toString() {
+        return new ToStringBuilder(this, ToStringStyle.SHORT_PREFIX_STYLE)
+            .append("principal", principal)
+            .append("credentials", credentials)
+            .toString();
+    }
+}

--- a/src/main/java/com/dokev/gold_dduck/jwt/JwtAuthenticationToken.java
+++ b/src/main/java/com/dokev/gold_dduck/jwt/JwtAuthenticationToken.java
@@ -1,11 +1,11 @@
 package com.dokev.gold_dduck.jwt;
 
 import java.util.Collection;
-import org.apache.commons.lang3.builder.ToStringBuilder;
-import org.apache.commons.lang3.builder.ToStringStyle;
+import lombok.ToString;
 import org.springframework.security.authentication.AbstractAuthenticationToken;
 import org.springframework.security.core.GrantedAuthority;
 
+@ToString(of = {"principal", "credentials"})
 public class JwtAuthenticationToken extends AbstractAuthenticationToken {
 
     private final Object principal;
@@ -21,8 +21,8 @@ public class JwtAuthenticationToken extends AbstractAuthenticationToken {
     }
 
     public JwtAuthenticationToken(
-        Collection<? extends GrantedAuthority> authorities,
-        Object principal, String credentials
+        Object principal, String credentials,
+        Collection<? extends GrantedAuthority> authorities
     ) {
         super(authorities);
         super.setAuthenticated(true);
@@ -53,13 +53,5 @@ public class JwtAuthenticationToken extends AbstractAuthenticationToken {
     public void eraseCredentials() {
         super.eraseCredentials();
         this.credentials = null;
-    }
-
-    @Override
-    public String toString() {
-        return new ToStringBuilder(this, ToStringStyle.SHORT_PREFIX_STYLE)
-            .append("principal", principal)
-            .append("credentials", credentials)
-            .toString();
     }
 }

--- a/src/main/java/com/dokev/gold_dduck/jwt/JwtProperties.java
+++ b/src/main/java/com/dokev/gold_dduck/jwt/JwtProperties.java
@@ -1,0 +1,23 @@
+package com.dokev.gold_dduck.jwt;
+
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+@ToString(of = {"header", "issuer", "clientSecret", "expirySeconds"})
+@Setter
+@Getter
+@Component
+@ConfigurationProperties(prefix = "jwt")
+public class JwtProperties {
+
+    private String header;
+
+    private String issuer;
+
+    private String clientSecret;
+
+    private int expirySeconds;
+}

--- a/src/main/java/com/dokev/gold_dduck/member/controller/MemberController.java
+++ b/src/main/java/com/dokev/gold_dduck/member/controller/MemberController.java
@@ -1,0 +1,27 @@
+package com.dokev.gold_dduck.member.controller;
+
+import com.dokev.gold_dduck.common.ApiResponse;
+import com.dokev.gold_dduck.jwt.JwtAuthentication;
+import com.dokev.gold_dduck.member.dto.MemberDto;
+import com.dokev.gold_dduck.member.service.MemberService;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api")
+public class MemberController {
+
+    private final MemberService memberService;
+
+    public MemberController(MemberService memberService) {
+        this.memberService = memberService;
+    }
+
+    @GetMapping("/v1/members/me")
+    public ApiResponse<MemberDto> me(@AuthenticationPrincipal JwtAuthentication authentication) {
+        MemberDto memberDto = memberService.findById(authentication.userId);
+        return ApiResponse.success(memberDto);
+    }
+}

--- a/src/main/java/com/dokev/gold_dduck/member/domain/Group.java
+++ b/src/main/java/com/dokev/gold_dduck/member/domain/Group.java
@@ -1,0 +1,39 @@
+package com.dokev.gold_dduck.member.domain;
+
+import static java.util.stream.Collectors.toList;
+
+import java.util.ArrayList;
+import java.util.List;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.OneToMany;
+import javax.persistence.Table;
+import lombok.Getter;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+
+@Getter
+@Table(name = "groups")
+@Entity
+public class Group {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "group_id")
+    private Long id;
+
+    @Column(name = "name")
+    private String name;
+
+    @OneToMany(mappedBy = "group")
+    private List<GroupPermission> groupPermissions = new ArrayList<>();
+
+    public List<GrantedAuthority> getAuthorities() {
+        return groupPermissions.stream()
+            .map(gp -> new SimpleGrantedAuthority(gp.getPermission().getName()))
+            .collect(toList());
+    }
+}

--- a/src/main/java/com/dokev/gold_dduck/member/domain/Group.java
+++ b/src/main/java/com/dokev/gold_dduck/member/domain/Group.java
@@ -11,10 +11,13 @@ import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.OneToMany;
 import javax.persistence.Table;
+import lombok.AccessLevel;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
 @Table(name = "groups")
 @Entity
@@ -35,5 +38,9 @@ public class Group {
         return groupPermissions.stream()
             .map(gp -> new SimpleGrantedAuthority(gp.getPermission().getName()))
             .collect(toList());
+    }
+
+    public Group(String name) {
+        this.name = name;
     }
 }

--- a/src/main/java/com/dokev/gold_dduck/member/domain/GroupPermission.java
+++ b/src/main/java/com/dokev/gold_dduck/member/domain/GroupPermission.java
@@ -8,8 +8,11 @@ import javax.persistence.Id;
 import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
 import javax.persistence.Table;
+import lombok.AccessLevel;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
 @Table(name = "group_permission")
 @Entity
@@ -27,4 +30,9 @@ public class GroupPermission {
     @ManyToOne(optional = false)
     @JoinColumn(name = "permission_id")
     private Permission permission;
+
+    public GroupPermission(Group group, Permission permission) {
+        this.group = group;
+        this.permission = permission;
+    }
 }

--- a/src/main/java/com/dokev/gold_dduck/member/domain/GroupPermission.java
+++ b/src/main/java/com/dokev/gold_dduck/member/domain/GroupPermission.java
@@ -1,0 +1,30 @@
+package com.dokev.gold_dduck.member.domain;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import javax.persistence.Table;
+import lombok.Getter;
+
+@Getter
+@Table(name = "group_permission")
+@Entity
+public class GroupPermission {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "group_permission_id")
+    private Long id;
+
+    @ManyToOne(optional = false)
+    @JoinColumn(name = "group_id")
+    private Group group;
+
+    @ManyToOne(optional = false)
+    @JoinColumn(name = "permission_id")
+    private Permission permission;
+}

--- a/src/main/java/com/dokev/gold_dduck/member/domain/Member.java
+++ b/src/main/java/com/dokev/gold_dduck/member/domain/Member.java
@@ -19,7 +19,9 @@ import javax.validation.constraints.Email;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.ToString;
 
+@ToString(of = {"id", "name", "email"})
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
 @Entity

--- a/src/main/java/com/dokev/gold_dduck/member/domain/Member.java
+++ b/src/main/java/com/dokev/gold_dduck/member/domain/Member.java
@@ -4,12 +4,15 @@ import com.dokev.gold_dduck.common.BaseEntity;
 import com.dokev.gold_dduck.event.domain.Event;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
 import javax.persistence.OneToMany;
 import javax.persistence.Table;
 import javax.validation.constraints.Email;
@@ -32,8 +35,11 @@ public class Member extends BaseEntity {
     private String name;
 
     @Email
-    @Column(name = "email", nullable = false, length = 30)
+    @Column(name = "email", length = 30)
     private String email;
+
+    @Column(name = "provider", nullable = false, length = 30)
+    private String provider;
 
     @Column(name = "social_id", nullable = false, length = 30)
     private String socialId;
@@ -44,14 +50,31 @@ public class Member extends BaseEntity {
     @OneToMany(mappedBy = "member")
     private final List<Event> events = new ArrayList<>();
 
-    public Optional<String> getProfileImage() {
-        return Optional.ofNullable(profileImage);
-    }
+    @ManyToOne
+    @JoinColumn(name = "group_id")
+    private Group group;
 
     public Member(String name, String email, String socialId, String profileImage) {
         this.name = name;
         this.email = email;
         this.socialId = socialId;
         this.profileImage = profileImage;
+    }
+
+    public Member(String name, String provider, String socialId, String profileImage, Group group) {
+        Objects.requireNonNull(name, "name must not be null");
+        Objects.requireNonNull(provider, "provider must not be null");
+        Objects.requireNonNull(socialId, "socialId must not be null");
+        Objects.requireNonNull(group, "group must not be null");
+
+        this.name = name;
+        this.provider = provider;
+        this.socialId = socialId;
+        this.profileImage = profileImage;
+        this.group = group;
+    }
+
+    public Optional<String> getProfileImage() {
+        return Optional.ofNullable(profileImage);
     }
 }

--- a/src/main/java/com/dokev/gold_dduck/member/domain/Permission.java
+++ b/src/main/java/com/dokev/gold_dduck/member/domain/Permission.java
@@ -6,9 +6,12 @@ import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.Table;
+import lombok.AccessLevel;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.ToString;
 
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @ToString(of = {"id", "name"})
 @Getter
 @Table(name = "permission")
@@ -22,4 +25,8 @@ public class Permission {
 
     @Column(name = "name")
     private String name;
+
+    public Permission(String name) {
+        this.name = name;
+    }
 }

--- a/src/main/java/com/dokev/gold_dduck/member/domain/Permission.java
+++ b/src/main/java/com/dokev/gold_dduck/member/domain/Permission.java
@@ -1,0 +1,25 @@
+package com.dokev.gold_dduck.member.domain;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.Table;
+import lombok.Getter;
+import lombok.ToString;
+
+@ToString(of = {"id", "name"})
+@Getter
+@Table(name = "permission")
+@Entity
+public class Permission {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "permission_id")
+    private Long id;
+
+    @Column(name = "name")
+    private String name;
+}

--- a/src/main/java/com/dokev/gold_dduck/member/domain/RoleGroupType.java
+++ b/src/main/java/com/dokev/gold_dduck/member/domain/RoleGroupType.java
@@ -1,0 +1,28 @@
+package com.dokev.gold_dduck.member.domain;
+
+import java.util.Arrays;
+import lombok.Getter;
+
+@Getter
+public enum RoleGroupType {
+
+    USER("USER_GROUP", "일반 사용자 그룹"),
+    ADMIN("ADMIN_GROUP", "관리자 그룹"),
+    GUEST("GUEST_GROUP", "게스트 그룹");
+
+    private final String code;
+
+    private final String displayName;
+
+    RoleGroupType(String code, String displayName) {
+        this.code = code;
+        this.displayName = displayName;
+    }
+
+    public static RoleGroupType of(String code) {
+        return Arrays.stream(RoleGroupType.values())
+            .filter(role -> role.getCode().equals(code))
+            .findAny()
+            .orElse(GUEST);
+    }
+}

--- a/src/main/java/com/dokev/gold_dduck/member/domain/RoleType.java
+++ b/src/main/java/com/dokev/gold_dduck/member/domain/RoleType.java
@@ -1,0 +1,28 @@
+package com.dokev.gold_dduck.member.domain;
+
+import java.util.Arrays;
+import lombok.Getter;
+
+@Getter
+public enum RoleType {
+
+    USER("ROLE_USER", "일반 사용자 권한"),
+    ADMIN("ROLE_ADMIN", "관리자 권한"),
+    GUEST("GUEST", "게스트 권한");
+
+    private final String code;
+
+    private final String displayName;
+
+    RoleType(String code, String displayName) {
+        this.code = code;
+        this.displayName = displayName;
+    }
+
+    public static RoleType of(String code) {
+        return Arrays.stream(RoleType.values())
+            .filter(role -> role.getCode().equals(code))
+            .findAny()
+            .orElse(GUEST);
+    }
+}

--- a/src/main/java/com/dokev/gold_dduck/member/dto/MemberDto.java
+++ b/src/main/java/com/dokev/gold_dduck/member/dto/MemberDto.java
@@ -1,5 +1,6 @@
 package com.dokev.gold_dduck.member.dto;
 
+import com.dokev.gold_dduck.member.domain.Member;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -24,5 +25,12 @@ public class MemberDto {
         this.email = email;
         this.socialId = socialId;
         this.profileImage = profileImage;
+    }
+
+    public MemberDto(Member member) {
+        this.id = member.getId();
+        this.name = member.getName();
+        this.email = member.getEmail();
+        this.profileImage = member.getProfileImage().orElse(null);
     }
 }

--- a/src/main/java/com/dokev/gold_dduck/member/repository/GroupRepository.java
+++ b/src/main/java/com/dokev/gold_dduck/member/repository/GroupRepository.java
@@ -1,0 +1,10 @@
+package com.dokev.gold_dduck.member.repository;
+
+import com.dokev.gold_dduck.member.domain.Group;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface GroupRepository extends JpaRepository<Group, Long> {
+
+    Optional<Group> findByName(String name);
+}

--- a/src/main/java/com/dokev/gold_dduck/member/repository/MemberRepository.java
+++ b/src/main/java/com/dokev/gold_dduck/member/repository/MemberRepository.java
@@ -1,8 +1,24 @@
 package com.dokev.gold_dduck.member.repository;
 
 import com.dokev.gold_dduck.member.domain.Member;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface MemberRepository extends JpaRepository<Member, Long> {
 
+    @Query("select m from Member m"
+        + " join fetch m.group g"
+        + " left join fetch g.groupPermissions gp"
+        + " left join fetch gp.permission p"
+        + " where m.name = :name")
+    Optional<Member> findByName(@Param("name") String name);
+
+    @Query("select m from Member m"
+        + " join fetch m.group g"
+        + " left join fetch g.groupPermissions gp"
+        + " left join fetch gp.permission p"
+        + " where m.provider = :provider and m.socialId = :socialId")
+    Optional<Member> findByProviderAndSocialId(@Param("provider") String provider, @Param("socialId") String socialId);
 }

--- a/src/main/java/com/dokev/gold_dduck/member/repository/MemberRepository.java
+++ b/src/main/java/com/dokev/gold_dduck/member/repository/MemberRepository.java
@@ -8,12 +8,7 @@ import org.springframework.data.repository.query.Param;
 
 public interface MemberRepository extends JpaRepository<Member, Long> {
 
-    @Query("select m from Member m"
-        + " join fetch m.group g"
-        + " left join fetch g.groupPermissions gp"
-        + " left join fetch gp.permission p"
-        + " where m.name = :name")
-    Optional<Member> findByName(@Param("name") String name);
+    Optional<Member> findSimpleById(Long id);
 
     @Query("select m from Member m"
         + " join fetch m.group g"

--- a/src/main/java/com/dokev/gold_dduck/member/service/MemberService.java
+++ b/src/main/java/com/dokev/gold_dduck/member/service/MemberService.java
@@ -1,0 +1,59 @@
+package com.dokev.gold_dduck.member.service;
+
+import com.dokev.gold_dduck.member.domain.Group;
+import com.dokev.gold_dduck.member.domain.Member;
+import com.dokev.gold_dduck.member.repository.GroupRepository;
+import com.dokev.gold_dduck.member.repository.MemberRepository;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Transactional(readOnly = true)
+@Service
+public class MemberService {
+
+    private final MemberRepository memberRepository;
+
+    private final GroupRepository groupRepository;
+
+    public MemberService(MemberRepository memberRepository,
+        GroupRepository groupRepository) {
+        this.memberRepository = memberRepository;
+        this.groupRepository = groupRepository;
+    }
+
+    public Optional<Member> findByName(String name) {
+        return memberRepository.findByName(name);
+    }
+
+    public Optional<Member> findByProviderAndSocialId(String provider, String socialId) {
+        return memberRepository.findByProviderAndSocialId(provider, socialId);
+    }
+
+    @Transactional
+    public Member join(OAuth2User oauth2User, String provider) {
+        String socialId = oauth2User.getName();
+        return findByProviderAndSocialId(provider, socialId)
+            .map(member -> {
+                log.warn("Already exists: {} for provider: {} socialId: {}", member, provider, socialId);
+                return member;
+            })
+            .orElseGet(() -> {
+                Map<String, Object> attributes = oauth2User.getAttributes();
+                @SuppressWarnings("unchecked")
+                Map<String, Object> properties = (Map<String, Object>) attributes.get("properties");
+                Objects.requireNonNull(properties, "OAuth2User properties is empty");
+
+                String nickname = (String) properties.get("nickname");
+                String profileImage = (String) properties.get("profile_image");
+                Group group = groupRepository.findByName("USER_GROUP")
+                    .orElseThrow(() -> new IllegalStateException("Could not found group for USER_GROUP"));
+                return memberRepository.save(new Member(nickname, provider, socialId, profileImage, group));
+            });
+    }
+}

--- a/src/main/java/com/dokev/gold_dduck/oauth2/HttpCookieOAuth2AuthorizationRequestRepository.java
+++ b/src/main/java/com/dokev/gold_dduck/oauth2/HttpCookieOAuth2AuthorizationRequestRepository.java
@@ -1,0 +1,60 @@
+package com.dokev.gold_dduck.oauth2;
+
+import com.dokev.gold_dduck.common.util.CookieUtil;
+import com.nimbusds.oauth2.sdk.util.StringUtils;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import org.springframework.security.oauth2.client.web.AuthorizationRequestRepository;
+import org.springframework.security.oauth2.core.endpoint.OAuth2AuthorizationRequest;
+
+public class HttpCookieOAuth2AuthorizationRequestRepository implements
+    AuthorizationRequestRepository<OAuth2AuthorizationRequest> {
+
+    public final static String OAUTH2_AUTHORIZATION_REQUEST_COOKIE_NAME = "oauth2_auth_request";
+
+    public final static String REDIRECT_URI_PARAM_COOKIE_NAME = "redirect_uri";
+
+    public final static String REFRESH_TOKEN = "refresh_token";
+
+    private final static int cookieExpireSeconds = 180;
+
+    @Override
+    public OAuth2AuthorizationRequest loadAuthorizationRequest(HttpServletRequest request) {
+        return CookieUtil.getCookie(request, OAUTH2_AUTHORIZATION_REQUEST_COOKIE_NAME)
+            .map(cookie -> CookieUtil.deserialize(cookie, OAuth2AuthorizationRequest.class))
+            .orElse(null);
+    }
+
+    @Override
+    public void saveAuthorizationRequest(OAuth2AuthorizationRequest authorizationRequest, HttpServletRequest request, HttpServletResponse response) {
+        if (authorizationRequest == null) {
+            CookieUtil.deleteCookie(request, response, OAUTH2_AUTHORIZATION_REQUEST_COOKIE_NAME);
+            CookieUtil.deleteCookie(request, response, REDIRECT_URI_PARAM_COOKIE_NAME);
+            CookieUtil.deleteCookie(request, response, REFRESH_TOKEN);
+            return;
+        }
+
+        CookieUtil.addCookie(response, OAUTH2_AUTHORIZATION_REQUEST_COOKIE_NAME, CookieUtil.serialize(authorizationRequest), cookieExpireSeconds);
+        String redirectUriAfterLogin = request.getParameter(REDIRECT_URI_PARAM_COOKIE_NAME);
+        if (StringUtils.isNotBlank(redirectUriAfterLogin)) {
+            CookieUtil.addCookie(response, REDIRECT_URI_PARAM_COOKIE_NAME, redirectUriAfterLogin, cookieExpireSeconds);
+        }
+    }
+
+    @Override
+    public OAuth2AuthorizationRequest removeAuthorizationRequest(HttpServletRequest request) {
+        return this.loadAuthorizationRequest(request);
+    }
+
+    @Override
+    public OAuth2AuthorizationRequest removeAuthorizationRequest(HttpServletRequest request, HttpServletResponse response) {
+        return this.loadAuthorizationRequest(request);
+    }
+
+    public void removeAuthorizationRequestCookies(HttpServletRequest request, HttpServletResponse response) {
+        CookieUtil.deleteCookie(request, response, OAUTH2_AUTHORIZATION_REQUEST_COOKIE_NAME);
+        CookieUtil.deleteCookie(request, response, REDIRECT_URI_PARAM_COOKIE_NAME);
+        CookieUtil.deleteCookie(request, response, REFRESH_TOKEN);
+    }
+
+}

--- a/src/main/java/com/dokev/gold_dduck/oauth2/HttpCookieOAuth2AuthorizationRequestRepository.java
+++ b/src/main/java/com/dokev/gold_dduck/oauth2/HttpCookieOAuth2AuthorizationRequestRepository.java
@@ -10,13 +10,11 @@ import org.springframework.security.oauth2.core.endpoint.OAuth2AuthorizationRequ
 public class HttpCookieOAuth2AuthorizationRequestRepository implements
     AuthorizationRequestRepository<OAuth2AuthorizationRequest> {
 
-    public final static String OAUTH2_AUTHORIZATION_REQUEST_COOKIE_NAME = "oauth2_auth_request";
+    private final String OAUTH2_AUTHORIZATION_REQUEST_COOKIE_NAME = "oauth2_auth_request";
 
-    public final static String REDIRECT_URI_PARAM_COOKIE_NAME = "redirect_uri";
+    public static final String REDIRECT_URI_PARAM_COOKIE_NAME = "redirect_uri";
 
-    public final static String REFRESH_TOKEN = "refresh_token";
-
-    private final static int cookieExpireSeconds = 180;
+    private final int cookieExpireSeconds = 180;
 
     @Override
     public OAuth2AuthorizationRequest loadAuthorizationRequest(HttpServletRequest request) {
@@ -26,15 +24,16 @@ public class HttpCookieOAuth2AuthorizationRequestRepository implements
     }
 
     @Override
-    public void saveAuthorizationRequest(OAuth2AuthorizationRequest authorizationRequest, HttpServletRequest request, HttpServletResponse response) {
+    public void saveAuthorizationRequest(OAuth2AuthorizationRequest authorizationRequest, HttpServletRequest request,
+        HttpServletResponse response) {
         if (authorizationRequest == null) {
             CookieUtil.deleteCookie(request, response, OAUTH2_AUTHORIZATION_REQUEST_COOKIE_NAME);
             CookieUtil.deleteCookie(request, response, REDIRECT_URI_PARAM_COOKIE_NAME);
-            CookieUtil.deleteCookie(request, response, REFRESH_TOKEN);
             return;
         }
 
-        CookieUtil.addCookie(response, OAUTH2_AUTHORIZATION_REQUEST_COOKIE_NAME, CookieUtil.serialize(authorizationRequest), cookieExpireSeconds);
+        CookieUtil.addCookie(response, OAUTH2_AUTHORIZATION_REQUEST_COOKIE_NAME,
+            CookieUtil.serialize(authorizationRequest), cookieExpireSeconds);
         String redirectUriAfterLogin = request.getParameter(REDIRECT_URI_PARAM_COOKIE_NAME);
         if (StringUtils.isNotBlank(redirectUriAfterLogin)) {
             CookieUtil.addCookie(response, REDIRECT_URI_PARAM_COOKIE_NAME, redirectUriAfterLogin, cookieExpireSeconds);
@@ -47,14 +46,14 @@ public class HttpCookieOAuth2AuthorizationRequestRepository implements
     }
 
     @Override
-    public OAuth2AuthorizationRequest removeAuthorizationRequest(HttpServletRequest request, HttpServletResponse response) {
+    public OAuth2AuthorizationRequest removeAuthorizationRequest(HttpServletRequest request,
+        HttpServletResponse response) {
         return this.loadAuthorizationRequest(request);
     }
 
     public void removeAuthorizationRequestCookies(HttpServletRequest request, HttpServletResponse response) {
         CookieUtil.deleteCookie(request, response, OAUTH2_AUTHORIZATION_REQUEST_COOKIE_NAME);
         CookieUtil.deleteCookie(request, response, REDIRECT_URI_PARAM_COOKIE_NAME);
-        CookieUtil.deleteCookie(request, response, REFRESH_TOKEN);
     }
 
 }

--- a/src/main/java/com/dokev/gold_dduck/oauth2/OAuth2AuthenticationSuccessHandler.java
+++ b/src/main/java/com/dokev/gold_dduck/oauth2/OAuth2AuthenticationSuccessHandler.java
@@ -1,0 +1,82 @@
+package com.dokev.gold_dduck.oauth2;
+
+import com.dokev.gold_dduck.common.util.CookieUtil;
+import com.dokev.gold_dduck.jwt.Jwt;
+import com.dokev.gold_dduck.member.domain.Member;
+import com.dokev.gold_dduck.member.service.MemberService;
+import java.io.IOException;
+import java.util.Optional;
+import javax.servlet.ServletException;
+import javax.servlet.http.Cookie;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.security.web.authentication.SavedRequestAwareAuthenticationSuccessHandler;
+import org.springframework.web.util.UriComponentsBuilder;
+
+@Slf4j
+public class OAuth2AuthenticationSuccessHandler extends SavedRequestAwareAuthenticationSuccessHandler {
+
+    private final Jwt jwt;
+
+    private final MemberService memberService;
+
+    public final static String REDIRECT_URI_PARAM_COOKIE_NAME = "redirect_uri";
+
+    public OAuth2AuthenticationSuccessHandler(Jwt jwt, MemberService memberService) {
+        this.jwt = jwt;
+        this.memberService = memberService;
+    }
+
+    @Override
+    public void onAuthenticationSuccess(
+        HttpServletRequest request,
+        HttpServletResponse response,
+        Authentication authentication
+    ) throws ServletException, IOException {
+        Object principal = authentication.getPrincipal();
+        log.info("OAuth2 authentication success: {}", principal);
+
+        if (authentication instanceof OAuth2AuthenticationToken) {
+            OAuth2AuthenticationToken oauth2Token = (OAuth2AuthenticationToken) authentication;
+            OAuth2User oauth2User = oauth2Token.getPrincipal();
+            String provider = oauth2Token.getAuthorizedClientRegistrationId();
+            Member member = processMemberOAuth2UserJoin(oauth2User, provider);
+            String token = generateToken(member);
+            String redirectUri = determineTargetUrl(request, response, authentication);
+            String targetUrl = UriComponentsBuilder
+                .fromUriString(redirectUri).queryParam("token", token)
+                .build().toUriString();
+            clearAuthenticationAttributes(request, response);
+            getRedirectStrategy().sendRedirect(request, response, targetUrl);
+            log.info("redirectUri : {}", redirectUri);
+            log.info("targetUrl : {}", targetUrl);
+        } else {
+            super.onAuthenticationSuccess(request, response, authentication);
+        }
+    }
+
+    private Member processMemberOAuth2UserJoin(OAuth2User oauth2User, String provider) {
+        return memberService.join(oauth2User, provider);
+    }
+
+    private String generateToken(Member member) {
+        return jwt.sign(Jwt.Claims.from(member.getName(), new String[]{"ROLE_USER"}));
+    }
+
+    @Override
+    protected String determineTargetUrl(HttpServletRequest request, HttpServletResponse response,
+        Authentication authentication) {
+        Optional<String> redirectUri = CookieUtil.getCookie(request, REDIRECT_URI_PARAM_COOKIE_NAME)
+            .map(Cookie::getValue);
+        return redirectUri.orElse(getDefaultTargetUrl());
+    }
+
+    protected void clearAuthenticationAttributes(HttpServletRequest request, HttpServletResponse response) {
+//        super.clearAuthenticationAttributes(request);
+//        authorizationRequestRepository.removeAuthorizationRequestCookies(request, response);
+    }
+}

--- a/src/test/java/com/dokev/gold_dduck/event/controller/EventControllerTest.java
+++ b/src/test/java/com/dokev/gold_dduck/event/controller/EventControllerTest.java
@@ -59,7 +59,7 @@ class EventControllerTest {
     @DisplayName("이벤트 생성 테스트 - 성공")
     void saveEventTest() throws Exception {
         // GIVEN
-        Member testMember = TestMemberFactory.givenMembers(entityManager).getUserMember();
+        Member testMember = TestMemberFactory.getUserMember(entityManager);
 
         Event newEvent = TestEventFactory.createEvent(testMember);
 
@@ -86,7 +86,7 @@ class EventControllerTest {
     @DisplayName("이벤트 조회 테스트 - 성공")
     void findEventByCode() throws Exception {
         //given
-        Member member = TestMemberFactory.givenMembers(entityManager).getUserMember();
+        Member member = TestMemberFactory.getUserMember(entityManager);
 
         Event event = TestEventFactory.createEvent(member);
         event.changeMember(member);
@@ -124,7 +124,7 @@ class EventControllerTest {
     @DisplayName("이벤트 생성 실패 (존재하지 않는 memberId)")
     void saveEventFailureTest() throws Exception {
         // GIVEN
-        Member testMember = TestMemberFactory.givenMembers(entityManager).getUserMember();
+        Member testMember = TestMemberFactory.getUserMember(entityManager);
 
         Event newEvent = TestEventFactory.createEvent(testMember);
 
@@ -153,7 +153,7 @@ class EventControllerTest {
     @DisplayName("이벤트 생성 실패 (Invalid Input Value - 선물, 선물 아이템이 비어 있는 경우)")
     void saveEventFailureTest2() throws Exception {
         // GIVEN
-        Member testMember = TestMemberFactory.givenMembers(entityManager).getUserMember();
+        Member testMember = TestMemberFactory.getUserMember(entityManager);
 
         Event newEvent = TestEventFactory.builder(testMember).build();
 

--- a/src/test/java/com/dokev/gold_dduck/event/controller/EventControllerTest.java
+++ b/src/test/java/com/dokev/gold_dduck/event/controller/EventControllerTest.java
@@ -20,6 +20,7 @@ import com.dokev.gold_dduck.event.dto.EventSaveDto;
 import com.dokev.gold_dduck.factory.TestEventFactory;
 import com.dokev.gold_dduck.factory.TestMemberFactory;
 import com.dokev.gold_dduck.member.domain.Member;
+import com.dokev.gold_dduck.security.WithMockJwtAuthentication;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.util.UUID;
 import javax.persistence.EntityManager;
@@ -33,6 +34,7 @@ import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.transaction.annotation.Transactional;
 
+@WithMockJwtAuthentication
 @Transactional
 @AutoConfigureMockMvc
 @SpringBootTest
@@ -57,8 +59,7 @@ class EventControllerTest {
     @DisplayName("이벤트 생성 테스트 - 성공")
     void saveEventTest() throws Exception {
         // GIVEN
-        Member testMember = TestMemberFactory.createTestMember();
-        entityManager.persist(testMember);
+        Member testMember = TestMemberFactory.givenMembers(entityManager).getUserMember();
 
         Event newEvent = TestEventFactory.createEvent(testMember);
 
@@ -85,8 +86,7 @@ class EventControllerTest {
     @DisplayName("이벤트 조회 테스트 - 성공")
     void findEventByCode() throws Exception {
         //given
-        Member member = TestMemberFactory.createTestMember();
-        entityManager.persist(member);
+        Member member = TestMemberFactory.givenMembers(entityManager).getUserMember();
 
         Event event = TestEventFactory.createEvent(member);
         event.changeMember(member);
@@ -124,13 +124,12 @@ class EventControllerTest {
     @DisplayName("이벤트 생성 실패 (존재하지 않는 memberId)")
     void saveEventFailureTest() throws Exception {
         // GIVEN
-        Member testMember = TestMemberFactory.createTestMember();
-        entityManager.persist(testMember);
+        Member testMember = TestMemberFactory.givenMembers(entityManager).getUserMember();
 
         Event newEvent = TestEventFactory.createEvent(testMember);
 
         EventSaveDto eventSaveDto = eventSaveConverter.convertToEventSaveDto(newEvent);
-        eventSaveDto.changedMemberId(eventSaveDto.getMemberId() + 1L);
+        eventSaveDto.changedMemberId(-1L);
 
         // WHEN
         ResultActions resultActions = mockMvc.perform(
@@ -154,8 +153,7 @@ class EventControllerTest {
     @DisplayName("이벤트 생성 실패 (Invalid Input Value - 선물, 선물 아이템이 비어 있는 경우)")
     void saveEventFailureTest2() throws Exception {
         // GIVEN
-        Member testMember = TestMemberFactory.createTestMember();
-        entityManager.persist(testMember);
+        Member testMember = TestMemberFactory.givenMembers(entityManager).getUserMember();
 
         Event newEvent = TestEventFactory.builder(testMember).build();
 

--- a/src/test/java/com/dokev/gold_dduck/event/repository/EventLogRepositoryTest.java
+++ b/src/test/java/com/dokev/gold_dduck/event/repository/EventLogRepositoryTest.java
@@ -8,6 +8,7 @@ import com.dokev.gold_dduck.event.domain.EventLog;
 import com.dokev.gold_dduck.factory.TestEventFactory;
 import com.dokev.gold_dduck.factory.TestMemberFactory;
 import com.dokev.gold_dduck.member.domain.Member;
+import javax.persistence.EntityManager;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -22,7 +23,7 @@ import org.springframework.context.annotation.Import;
 class EventLogRepositoryTest {
 
     @Autowired
-    private TestEntityManager entityManager;
+    private EntityManager entityManager;
 
     @Autowired
     private EventLogRepository sut;
@@ -31,8 +32,7 @@ class EventLogRepositoryTest {
     @DisplayName("Event Id와 Member Id를 조건으로 일치하는 EventLog 검색 - 성공 테스트")
     void existsByEventIdAndMemberIdSuccessTest() {
         //given
-        Member member = TestMemberFactory.createTestMember();
-        entityManager.persist(member);
+        Member member = TestMemberFactory.givenMembers(entityManager).getUserMember();
         Event event = TestEventFactory.builder(member).build();
         entityManager.persist(event);
         entityManager.persist(new EventLog(event, member, null, null));

--- a/src/test/java/com/dokev/gold_dduck/event/repository/EventLogRepositoryTest.java
+++ b/src/test/java/com/dokev/gold_dduck/event/repository/EventLogRepositoryTest.java
@@ -14,7 +14,6 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
-import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
 import org.springframework.context.annotation.Import;
 
 @Import(JpaAuditingConfiguration.class)
@@ -32,7 +31,7 @@ class EventLogRepositoryTest {
     @DisplayName("Event Id와 Member Id를 조건으로 일치하는 EventLog 검색 - 성공 테스트")
     void existsByEventIdAndMemberIdSuccessTest() {
         //given
-        Member member = TestMemberFactory.givenMembers(entityManager).getUserMember();
+        Member member = TestMemberFactory.getUserMember(entityManager);
         Event event = TestEventFactory.builder(member).build();
         entityManager.persist(event);
         entityManager.persist(new EventLog(event, member, null, null));

--- a/src/test/java/com/dokev/gold_dduck/event/repository/EventRepositoryTest.java
+++ b/src/test/java/com/dokev/gold_dduck/event/repository/EventRepositoryTest.java
@@ -37,7 +37,7 @@ class EventRepositoryTest {
     void findGiftsByEventCode() {
         UUID eventCode = UUID.randomUUID();
 
-        Member member = TestMemberFactory.givenMembers(entityManager).getUserMember();
+        Member member = TestMemberFactory.getUserMember(entityManager);
 
         Event event = TestEventFactory.builder(member)
                 .code(eventCode)

--- a/src/test/java/com/dokev/gold_dduck/event/repository/EventRepositoryTest.java
+++ b/src/test/java/com/dokev/gold_dduck/event/repository/EventRepositoryTest.java
@@ -8,8 +8,10 @@ import com.dokev.gold_dduck.gift.domain.Gift;
 import com.dokev.gold_dduck.gift.domain.GiftItem;
 import com.dokev.gold_dduck.gift.domain.GiftType;
 import com.dokev.gold_dduck.member.domain.Member;
+import com.dokev.gold_dduck.member.repository.MemberRepository;
 import java.util.Optional;
 import java.util.UUID;
+import javax.persistence.EntityManager;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -25,7 +27,7 @@ import org.springframework.context.annotation.Import;
 class EventRepositoryTest {
 
     @Autowired
-    private TestEntityManager entityManager;
+    private EntityManager entityManager;
 
     @Autowired
     private EventRepository eventRepository;
@@ -35,8 +37,7 @@ class EventRepositoryTest {
     void findGiftsByEventCode() {
         UUID eventCode = UUID.randomUUID();
 
-        Member member = TestMemberFactory.createTestMember();
-        entityManager.persist(member);
+        Member member = TestMemberFactory.givenMembers(entityManager).getUserMember();
 
         Event event = TestEventFactory.builder(member)
                 .code(eventCode)

--- a/src/test/java/com/dokev/gold_dduck/factory/TestMemberFactory.java
+++ b/src/test/java/com/dokev/gold_dduck/factory/TestMemberFactory.java
@@ -1,10 +1,59 @@
 package com.dokev.gold_dduck.factory;
 
+import com.dokev.gold_dduck.member.domain.Group;
+import com.dokev.gold_dduck.member.domain.GroupPermission;
 import com.dokev.gold_dduck.member.domain.Member;
+import com.dokev.gold_dduck.member.domain.Permission;
+import com.dokev.gold_dduck.member.domain.RoleGroupType;
+import com.dokev.gold_dduck.member.domain.RoleType;
+import javax.persistence.EntityManager;
 
 public class TestMemberFactory {
 
     public static Member createTestMember() {
         return new Member("dokev", "dokev@gmail.com", "id123", "http://dokev/image.jpg");
+    }
+
+    public static TestMembers givenMembers(EntityManager entityManager) {
+        Permission roleUser = new Permission(RoleType.USER.getCode());
+        Permission roleAdmin = new Permission(RoleType.ADMIN.getCode());
+        Group userGroup = new Group(RoleGroupType.USER.getCode());
+        Group adminGroup = new Group(RoleGroupType.ADMIN.getCode());
+        GroupPermission userGroupPermission = new GroupPermission(userGroup, roleUser);
+        GroupPermission adminGroupPermission = new GroupPermission(adminGroup, roleUser);
+        GroupPermission adminGroupPermission2 = new GroupPermission(adminGroup, roleAdmin);
+        Member userMember = new Member("user_dokev", "kakao", "id123", "http://dokev/image.jpg", userGroup);
+        Member adminMember = new Member("admin_dokev", "kakao", "id456", "http://dokev/image.jpg", adminGroup);
+        entityManager.persist(roleUser);
+        entityManager.persist(roleAdmin);
+        entityManager.persist(userGroup);
+        entityManager.persist(adminGroup);
+        entityManager.persist(userGroupPermission);
+        entityManager.persist(adminGroupPermission);
+        entityManager.persist(adminGroupPermission2);
+        entityManager.persist(userMember);
+        entityManager.persist(adminMember);
+        return new TestMembers(userMember, adminMember);
+    }
+
+
+    public static class TestMembers {
+
+        private final Member userMember;
+
+        private final Member adminMember;
+
+        public TestMembers(Member userMember, Member adminMember) {
+            this.userMember = userMember;
+            this.adminMember = adminMember;
+        }
+
+        public Member getUserMember() {
+            return userMember;
+        }
+
+        public Member getAdminMember() {
+            return adminMember;
+        }
     }
 }

--- a/src/test/java/com/dokev/gold_dduck/factory/TestMemberFactory.java
+++ b/src/test/java/com/dokev/gold_dduck/factory/TestMemberFactory.java
@@ -14,46 +14,11 @@ public class TestMemberFactory {
         return new Member("dokev", "dokev@gmail.com", "id123", "http://dokev/image.jpg");
     }
 
-    public static TestMembers givenMembers(EntityManager entityManager) {
-        Permission roleUser = new Permission(RoleType.USER.getCode());
-        Permission roleAdmin = new Permission(RoleType.ADMIN.getCode());
-        Group userGroup = new Group(RoleGroupType.USER.getCode());
-        Group adminGroup = new Group(RoleGroupType.ADMIN.getCode());
-        GroupPermission userGroupPermission = new GroupPermission(userGroup, roleUser);
-        GroupPermission adminGroupPermission = new GroupPermission(adminGroup, roleUser);
-        GroupPermission adminGroupPermission2 = new GroupPermission(adminGroup, roleAdmin);
-        Member userMember = new Member("user_dokev", "kakao", "id123", "http://dokev/image.jpg", userGroup);
-        Member adminMember = new Member("admin_dokev", "kakao", "id456", "http://dokev/image.jpg", adminGroup);
-        entityManager.persist(roleUser);
-        entityManager.persist(roleAdmin);
-        entityManager.persist(userGroup);
-        entityManager.persist(adminGroup);
-        entityManager.persist(userGroupPermission);
-        entityManager.persist(adminGroupPermission);
-        entityManager.persist(adminGroupPermission2);
-        entityManager.persist(userMember);
-        entityManager.persist(adminMember);
-        return new TestMembers(userMember, adminMember);
+    public static Member getUserMember(EntityManager entityManager) {
+        return entityManager.find(Member.class, 1L);
     }
 
-
-    public static class TestMembers {
-
-        private final Member userMember;
-
-        private final Member adminMember;
-
-        public TestMembers(Member userMember, Member adminMember) {
-            this.userMember = userMember;
-            this.adminMember = adminMember;
-        }
-
-        public Member getUserMember() {
-            return userMember;
-        }
-
-        public Member getAdminMember() {
-            return adminMember;
-        }
+    public static Member getAdminMember(EntityManager entityManager) {
+        return entityManager.find(Member.class, 2L);
     }
 }

--- a/src/test/java/com/dokev/gold_dduck/gift/controller/GiftControllerTest.java
+++ b/src/test/java/com/dokev/gold_dduck/gift/controller/GiftControllerTest.java
@@ -20,6 +20,7 @@ import com.dokev.gold_dduck.gift.domain.GiftItem;
 import com.dokev.gold_dduck.gift.dto.GiftFifoChoiceDto;
 import com.dokev.gold_dduck.gift.service.GiftService;
 import com.dokev.gold_dduck.member.domain.Member;
+import com.dokev.gold_dduck.security.WithMockJwtAuthentication;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import javax.persistence.EntityManager;
 import org.junit.jupiter.api.DisplayName;
@@ -32,6 +33,7 @@ import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.transaction.annotation.Transactional;
 
+@WithMockJwtAuthentication
 @Transactional
 @AutoConfigureMockMvc
 @SpringBootTest

--- a/src/test/java/com/dokev/gold_dduck/gift/controller/GiftControllerTest.java
+++ b/src/test/java/com/dokev/gold_dduck/gift/controller/GiftControllerTest.java
@@ -230,7 +230,7 @@ class GiftControllerTest {
     }
 
     private Member givenMember() {
-        Member member = TestMemberFactory.givenMembers(entityManager).getUserMember();
+        Member member = TestMemberFactory.getUserMember(entityManager);
         return member;
     }
 

--- a/src/test/java/com/dokev/gold_dduck/gift/controller/GiftControllerTest.java
+++ b/src/test/java/com/dokev/gold_dduck/gift/controller/GiftControllerTest.java
@@ -228,8 +228,7 @@ class GiftControllerTest {
     }
 
     private Member givenMember() {
-        Member member = TestMemberFactory.createTestMember();
-        entityManager.persist(member);
+        Member member = TestMemberFactory.givenMembers(entityManager).getUserMember();
         return member;
     }
 

--- a/src/test/java/com/dokev/gold_dduck/gift/service/GiftServiceTest.java
+++ b/src/test/java/com/dokev/gold_dduck/gift/service/GiftServiceTest.java
@@ -55,7 +55,7 @@ class GiftServiceTest {
     @DisplayName("선착순으로 선물 받기 성공 테스트")
     void chooseGiftItemByFIFOSuccessTest() {
         //given
-        Member savedMember = TestMemberFactory.givenMembers(entityManager).getUserMember();
+        Member savedMember = TestMemberFactory.getUserMember(entityManager);
         Event savedEvent = eventRepository.save(TestEventFactory.builder(savedMember).build());
         Gift gift = new Gift("커피", 20);
         gift.changeEvent(savedEvent);

--- a/src/test/java/com/dokev/gold_dduck/gift/service/GiftServiceTest.java
+++ b/src/test/java/com/dokev/gold_dduck/gift/service/GiftServiceTest.java
@@ -17,6 +17,7 @@ import com.dokev.gold_dduck.gift.repository.GiftItemRepository;
 import com.dokev.gold_dduck.gift.repository.GiftRepository;
 import com.dokev.gold_dduck.member.domain.Member;
 import com.dokev.gold_dduck.member.repository.MemberRepository;
+import javax.persistence.EntityManager;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -28,6 +29,9 @@ import org.springframework.context.annotation.Import;
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
 @DataJpaTest
 class GiftServiceTest {
+
+    @Autowired
+    private EntityManager entityManager;
 
     @Autowired
     private EventRepository eventRepository;
@@ -51,7 +55,7 @@ class GiftServiceTest {
     @DisplayName("선착순으로 선물 받기 성공 테스트")
     void chooseGiftItemByFIFOSuccessTest() {
         //given
-        Member savedMember = memberRepository.save(TestMemberFactory.createTestMember());
+        Member savedMember = TestMemberFactory.givenMembers(entityManager).getUserMember();
         Event savedEvent = eventRepository.save(TestEventFactory.builder(savedMember).build());
         Gift gift = new Gift("커피", 20);
         gift.changeEvent(savedEvent);

--- a/src/test/java/com/dokev/gold_dduck/security/WithMockJwtAuthentication.java
+++ b/src/test/java/com/dokev/gold_dduck/security/WithMockJwtAuthentication.java
@@ -1,0 +1,18 @@
+package com.dokev.gold_dduck.security;
+
+import com.dokev.gold_dduck.member.domain.RoleType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import org.springframework.security.test.context.support.WithSecurityContext;
+
+@Retention(RetentionPolicy.RUNTIME)
+@WithSecurityContext(factory = WithMockJwtAuthenticationSecurityContextFactory.class)
+public @interface WithMockJwtAuthentication {
+
+    long id() default 1L;
+
+    String name() default "dokev_user";
+
+    RoleType role() default RoleType.USER;
+
+}

--- a/src/test/java/com/dokev/gold_dduck/security/WithMockJwtAuthenticationSecurityContextFactory.java
+++ b/src/test/java/com/dokev/gold_dduck/security/WithMockJwtAuthenticationSecurityContextFactory.java
@@ -1,0 +1,27 @@
+package com.dokev.gold_dduck.security;
+
+import static org.springframework.security.core.authority.AuthorityUtils.createAuthorityList;
+
+import com.dokev.gold_dduck.jwt.JwtAuthentication;
+import com.dokev.gold_dduck.jwt.JwtAuthenticationToken;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.test.context.support.WithSecurityContextFactory;
+
+public class WithMockJwtAuthenticationSecurityContextFactory implements
+    WithSecurityContextFactory<WithMockJwtAuthentication> {
+
+    @Override
+    public SecurityContext createSecurityContext(WithMockJwtAuthentication annotation) {
+        SecurityContext context = SecurityContextHolder.createEmptyContext();
+        JwtAuthenticationToken authentication = new JwtAuthenticationToken(
+            new JwtAuthentication(
+                annotation.id(),
+                annotation.name()),
+            null,
+            createAuthorityList(annotation.role().getCode())
+        );
+        context.setAuthentication(authentication);
+        return context;
+    }
+}


### PR DESCRIPTION
## 📌 이슈 설명 <!-- 어떤 걸 만들었는지 대략적으로 설명해주세요 -->
[](https://maenguin.atlassian.net/browse/GD-121)
## ✅ PR 포인트 & 궁금한 점 <!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->
**카카오 로그인 하기를 구현했습니다**
* jwt를 사용해서 사용자 정보를 주고 받고
* oauth2를 사용해서 카카오 인증을 처리했습니다
* 스프링 시큐리티 테스트의 jwt mock을 사용하여 컨트롤러 테스트시 mock jwt를 사용할 수 있도록 했습니다
* 토큰은 accessToken만 사용하고 requestToken은 사용하지 않는걸로 구현했습니다
* 사용자가 토큰으로 자신의 정보를 확인할 수 있도록 Member 관련 api를 구현하였습니다
* 권한과 권한그룹으로 나누어서 권한을 그룹으로 관리 할 수 있도록 했습니다.