### PR TITLE
[GD-43] feat : 멤버의 이벤트 목록 조회 API 추가 (queryDSL 적용)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,6 +2,7 @@ plugins {
     id 'org.springframework.boot' version '2.5.6'
     id 'io.spring.dependency-management' version '1.0.11.RELEASE'
     id 'org.asciidoctor.convert' version '1.5.8'
+    id "com.ewerk.gradle.plugins.querydsl" version "1.0.10"
     id 'java'
 }
 
@@ -39,6 +40,7 @@ dependencies {
     implementation group: 'org.apache.commons', name: 'commons-lang3', version: '3.12.0'
     implementation 'io.springfox:springfox-boot-starter:3.0.0'
     testImplementation 'org.springframework.security:spring-security-test'
+    implementation 'com.querydsl:querydsl-jpa'
 }
 
 test {
@@ -60,4 +62,31 @@ task copyConfigSettings(type: Copy) {
 
 build {
     dependsOn copyConfigSettings
+}
+
+def querydslDir = "$buildDir/generated/querydsl"
+
+querydsl {
+    jpa = true
+    querydslSourcesDir = querydslDir
+}
+
+sourceSets {
+    main.java.srcDir querydslDir
+}
+
+configurations {
+    querydsl.extendsFrom compileClasspath
+}
+
+compileQuerydsl {
+    options.annotationProcessorPath = configurations.querydsl
+}
+
+project.afterEvaluate {
+    project.tasks.compileQuerydsl.options.compilerArgs = [
+            "-proc:only",
+            "-processor", project.querydsl.processors() +
+                    ',lombok.launch.AnnotationProcessorHider$AnnotationProcessor'
+    ]
 }

--- a/src/main/java/com/dokev/gold_dduck/common/PaginationDto.java
+++ b/src/main/java/com/dokev/gold_dduck/common/PaginationDto.java
@@ -1,0 +1,26 @@
+package com.dokev.gold_dduck.common;
+
+import lombok.Getter;
+import org.springframework.data.domain.Page;
+
+@Getter
+public class PaginationDto {
+
+    private int totalPages;
+
+    private long totalElements;
+
+    private int currentPage;
+
+    private long offset;
+
+    private int size;
+
+    public PaginationDto(Page page) {
+        this.totalPages = page.getTotalPages();
+        this.totalElements = page.getTotalElements();
+        this.currentPage = page.getPageable().getPageNumber();
+        this.offset = page.getPageable().getOffset();
+        this.size = page.getSize();
+    }
+}

--- a/src/main/java/com/dokev/gold_dduck/event/controller/EventController.java
+++ b/src/main/java/com/dokev/gold_dduck/event/controller/EventController.java
@@ -1,17 +1,23 @@
 package com.dokev.gold_dduck.event.controller;
 
 import com.dokev.gold_dduck.common.ApiResponse;
+import com.dokev.gold_dduck.event.domain.EventProgressStatus;
 import com.dokev.gold_dduck.event.dto.EventDto;
 import com.dokev.gold_dduck.event.dto.EventSaveDto;
+import com.dokev.gold_dduck.event.dto.EventSearchCondition;
+import com.dokev.gold_dduck.event.dto.EventSimpleListDto;
 import com.dokev.gold_dduck.event.service.EventService;
 import java.util.UUID;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @Slf4j
@@ -35,5 +41,15 @@ public class EventController {
     public ApiResponse<EventDto> findEventByCode(@PathVariable("event-code") UUID eventCode) {
         EventDto eventDto = eventService.findDetailEventByCode(eventCode);
         return ApiResponse.success(eventDto);
+    }
+
+    @GetMapping(value = "/v1/members/{memberId}/events")
+    public ApiResponse<EventSimpleListDto> searchSimpleDescByMember(
+        @PathVariable Long memberId,
+        @RequestParam(required = false) EventProgressStatus eventProgressStatus,
+        @PageableDefault(size = 4) Pageable pageable
+    ) {
+        EventSearchCondition eventSearchCondition = new EventSearchCondition(eventProgressStatus);
+        return ApiResponse.success(eventService.searchSimpleDescByMember(memberId, eventSearchCondition, pageable));
     }
 }

--- a/src/main/java/com/dokev/gold_dduck/event/converter/EventFindConverter.java
+++ b/src/main/java/com/dokev/gold_dduck/event/converter/EventFindConverter.java
@@ -2,6 +2,7 @@ package com.dokev.gold_dduck.event.converter;
 
 import com.dokev.gold_dduck.event.domain.Event;
 import com.dokev.gold_dduck.event.dto.EventDto;
+import com.dokev.gold_dduck.event.dto.EventSimpleDto;
 import com.dokev.gold_dduck.gift.converter.GiftConverter;
 import com.dokev.gold_dduck.gift.domain.Gift;
 import com.dokev.gold_dduck.gift.dto.GiftDto;
@@ -38,5 +39,11 @@ public class EventFindConverter {
         return new EventDto(event.getId(), event.getTitle(), event.getGiftChoiceType(), event.getStartAt(),
             event.getEndAt(), event.getCode(), event.getEventProgressStatus(), event.getMainTemplate(),
             event.getMaxParticipantCount(), memberDto, giftDtos);
+    }
+
+    public EventSimpleDto convertToEventSimpleDto(Event event) {
+        return new EventSimpleDto(event.getId(), event.getTitle(), event.getGiftChoiceType(), event.getStartAt(),
+            event.getEndAt(), event.getCode(), event.getEventProgressStatus(), event.getMainTemplate(),
+            event.getMaxParticipantCount(), event.getCreatedAt());
     }
 }

--- a/src/main/java/com/dokev/gold_dduck/event/dto/EventSearchCondition.java
+++ b/src/main/java/com/dokev/gold_dduck/event/dto/EventSearchCondition.java
@@ -1,0 +1,14 @@
+package com.dokev.gold_dduck.event.dto;
+
+import com.dokev.gold_dduck.event.domain.EventProgressStatus;
+import lombok.Getter;
+
+@Getter
+public class EventSearchCondition {
+
+    private EventProgressStatus eventProgressStatus;
+
+    public EventSearchCondition(EventProgressStatus eventProgressStatus) {
+        this.eventProgressStatus = eventProgressStatus;
+    }
+}

--- a/src/main/java/com/dokev/gold_dduck/event/dto/EventSimpleDto.java
+++ b/src/main/java/com/dokev/gold_dduck/event/dto/EventSimpleDto.java
@@ -1,0 +1,51 @@
+package com.dokev.gold_dduck.event.dto;
+
+import com.dokev.gold_dduck.event.domain.EventProgressStatus;
+import com.dokev.gold_dduck.event.domain.GiftChoiceType;
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonFormat.Shape;
+import java.time.LocalDateTime;
+import java.util.UUID;
+import lombok.Getter;
+
+@Getter
+public class EventSimpleDto {
+
+    private Long eventId;
+
+    private String title;
+
+    private GiftChoiceType giftChoiceType;
+
+    @JsonFormat(shape = Shape.STRING, timezone = "Asia/Seoul")
+    private LocalDateTime startAt;
+
+    @JsonFormat(shape = Shape.STRING, timezone = "Asia/Seoul")
+    private LocalDateTime endAt;
+
+    private UUID code;
+
+    private EventProgressStatus eventProgressStatus;
+
+    private String mainTemplate;
+
+    private Integer maxParticipantCount;
+
+    @JsonFormat(shape = Shape.STRING, timezone = "Asia/Seoul")
+    private LocalDateTime createdAt;
+
+    public EventSimpleDto(Long eventId, String title, GiftChoiceType giftChoiceType, LocalDateTime startAt,
+        LocalDateTime endAt, UUID code, EventProgressStatus eventProgressStatus, String mainTemplate,
+        Integer maxParticipantCount, LocalDateTime createdAt) {
+        this.eventId = eventId;
+        this.title = title;
+        this.giftChoiceType = giftChoiceType;
+        this.startAt = startAt;
+        this.endAt = endAt;
+        this.code = code;
+        this.eventProgressStatus = eventProgressStatus;
+        this.mainTemplate = mainTemplate;
+        this.maxParticipantCount = maxParticipantCount;
+        this.createdAt = createdAt;
+    }
+}

--- a/src/main/java/com/dokev/gold_dduck/event/dto/EventSimpleListDto.java
+++ b/src/main/java/com/dokev/gold_dduck/event/dto/EventSimpleListDto.java
@@ -1,0 +1,19 @@
+package com.dokev.gold_dduck.event.dto;
+
+import com.dokev.gold_dduck.common.PaginationDto;
+import java.util.List;
+import lombok.Getter;
+import org.springframework.data.domain.Page;
+
+@Getter
+public class EventSimpleListDto {
+
+    private List<EventSimpleDto> simpleEventList;
+
+    private PaginationDto pagination;
+
+    public EventSimpleListDto(Page<EventSimpleDto> page) {
+        this.simpleEventList = page.getContent();
+        this.pagination = new PaginationDto(page);
+    }
+}

--- a/src/main/java/com/dokev/gold_dduck/event/repository/EventRepository.java
+++ b/src/main/java/com/dokev/gold_dduck/event/repository/EventRepository.java
@@ -7,11 +7,11 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
-public interface EventRepository extends JpaRepository<Event, Long> {
+public interface EventRepository extends JpaRepository<Event, Long>, EventRepositoryCustom {
 
-    @Query("SELECT distinct  e FROM Event e"
-            + " JOIN FETCH e.gifts"
-            + " where e.code = :eventCode")
+    @Query("select distinct e from Event e"
+        + " join fetch e.gifts"
+        + " where e.code = :eventCode")
     Optional<Event> findEventByCodeWithGift(@Param("eventCode") UUID eventCode);
 
 }

--- a/src/main/java/com/dokev/gold_dduck/event/repository/EventRepositoryCustom.java
+++ b/src/main/java/com/dokev/gold_dduck/event/repository/EventRepositoryCustom.java
@@ -1,0 +1,11 @@
+package com.dokev.gold_dduck.event.repository;
+
+import com.dokev.gold_dduck.event.domain.Event;
+import com.dokev.gold_dduck.event.dto.EventSearchCondition;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+public interface EventRepositoryCustom {
+
+    Page<Event> searchSimpleDescByMember(Long memberId, EventSearchCondition eventSearchCondition, Pageable pageable);
+}

--- a/src/main/java/com/dokev/gold_dduck/event/repository/EventRepositoryCustomImpl.java
+++ b/src/main/java/com/dokev/gold_dduck/event/repository/EventRepositoryCustomImpl.java
@@ -1,0 +1,43 @@
+package com.dokev.gold_dduck.event.repository;
+
+import static com.dokev.gold_dduck.event.domain.QEvent.event;
+
+import com.dokev.gold_dduck.event.domain.Event;
+import com.dokev.gold_dduck.event.domain.EventProgressStatus;
+import com.dokev.gold_dduck.event.dto.EventSearchCondition;
+import com.querydsl.core.QueryResults;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import javax.persistence.EntityManager;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+
+public class EventRepositoryCustomImpl implements EventRepositoryCustom {
+
+    private final JPAQueryFactory queryFactory;
+
+    public EventRepositoryCustomImpl(EntityManager entityManager) {
+        this.queryFactory = new JPAQueryFactory(entityManager);
+    }
+
+    @Override
+    public Page<Event> searchSimpleDescByMember(Long memberId, EventSearchCondition eventSearchCondition, Pageable pageable) {
+        QueryResults<Event> eventQueryResults = queryFactory
+            .selectFrom(event)
+            .where(memberEq(memberId), eventProgressStatusEq(eventSearchCondition.getEventProgressStatus()))
+            .orderBy(event.createdAt.desc())
+            .offset(pageable.getOffset())
+            .limit(pageable.getPageSize())
+            .fetchResults();
+        return new PageImpl<>(eventQueryResults.getResults(), pageable, eventQueryResults.getTotal());
+    }
+
+    private BooleanExpression eventProgressStatusEq(EventProgressStatus eventProgressStatus) {
+        return eventProgressStatus != null ? event.eventProgressStatus.eq(eventProgressStatus) : null;
+    }
+
+    private BooleanExpression memberEq(Long memberId) {
+        return memberId != null ? event.member.id.eq(memberId) : null;
+    }
+}

--- a/src/main/java/com/dokev/gold_dduck/event/service/EventService.java
+++ b/src/main/java/com/dokev/gold_dduck/event/service/EventService.java
@@ -7,11 +7,16 @@ import com.dokev.gold_dduck.event.converter.EventSaveConverter;
 import com.dokev.gold_dduck.event.domain.Event;
 import com.dokev.gold_dduck.event.dto.EventDto;
 import com.dokev.gold_dduck.event.dto.EventSaveDto;
+import com.dokev.gold_dduck.event.dto.EventSearchCondition;
+import com.dokev.gold_dduck.event.dto.EventSimpleDto;
+import com.dokev.gold_dduck.event.dto.EventSimpleListDto;
 import com.dokev.gold_dduck.event.repository.EventRepository;
 import com.dokev.gold_dduck.member.domain.Member;
 import com.dokev.gold_dduck.member.repository.MemberRepository;
 import java.util.UUID;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -51,5 +56,14 @@ public class EventService {
             .orElseThrow(() -> new EntityNotFoundException(Event.class, eventCode));
 
         return eventFindConverter.convertToEventDto(event);
+    }
+
+    public EventSimpleListDto searchSimpleDescByMember(Long memberId, EventSearchCondition eventSearchCondition, Pageable pageable) {
+        if (!memberRepository.existsById(memberId)) {
+            throw new EntityNotFoundException(Member.class, memberId);
+        }
+        Page<EventSimpleDto> page = eventRepository.searchSimpleDescByMember(memberId, eventSearchCondition, pageable)
+            .map(eventFindConverter::convertToEventSimpleDto);
+        return new EventSimpleListDto(page);
     }
 }

--- a/src/main/java/com/dokev/gold_dduck/event/service/EventService.java
+++ b/src/main/java/com/dokev/gold_dduck/event/service/EventService.java
@@ -58,7 +58,11 @@ public class EventService {
         return eventFindConverter.convertToEventDto(event);
     }
 
-    public EventSimpleListDto searchSimpleDescByMember(Long memberId, EventSearchCondition eventSearchCondition, Pageable pageable) {
+    public EventSimpleListDto searchSimpleDescByMember(
+        Long memberId,
+        EventSearchCondition eventSearchCondition,
+        Pageable pageable
+    ) {
         if (!memberRepository.existsById(memberId)) {
             throw new EntityNotFoundException(Member.class, memberId);
         }

--- a/src/test/java/com/dokev/gold_dduck/event/controller/EventControllerTest.java
+++ b/src/test/java/com/dokev/gold_dduck/event/controller/EventControllerTest.java
@@ -197,7 +197,7 @@ class EventControllerTest {
     }
 
     @Test
-    @DisplayName("Member가 생성한 Event 최신순으로 페이징 조회 성공 테스트 - (page = 0, size = 4, 이벤트상태 = 전체)")
+    @DisplayName("Member가 생성한 Event 최신순으로 페이징 조회 성공 테스트 - (page = null, size = null, 이벤트상태 = null)")
     void searchSimpleDescByMemberSuccessTest() throws Exception {
         //given
         Member userMember = TestMemberFactory.getUserMember(entityManager);
@@ -227,10 +227,10 @@ class EventControllerTest {
                 handler().methodName("searchSimpleDescByMember"),
                 jsonPath("$.success", is(true)),
                 jsonPath("$.error", is(nullValue())),
-                jsonPath("$.data..eventId",
-                    containsInAnyOrder(closedEvent.getId().intValue(),
+                jsonPath("$.data.simpleEventList[*].eventId",
+                    contains(readyEvent.getId().intValue(),
                         runningEvent.getId().intValue(),
-                        readyEvent.getId().intValue())),
+                        closedEvent.getId().intValue())),
                 jsonPath("$.data.pagination.totalPages", is(1)),
                 jsonPath("$.data.pagination.totalElements", is(3)),
                 jsonPath("$.data.pagination.currentPage", is(0)),
@@ -240,7 +240,7 @@ class EventControllerTest {
     }
 
     @Test
-    @DisplayName("Member가 생성한 Event 최신순으로 페이징 조회 성공 테스트 - (page = 0, size = 4, 이벤트상태 = 완료)")
+    @DisplayName("Member가 생성한 Event 최신순으로 페이징 조회 성공 테스트 - (page = null, size = null, 이벤트상태 = 완료)")
     void searchSimpleDescByMemberSuccessTest2() throws Exception {
         //given
         Member userMember = TestMemberFactory.getUserMember(entityManager);
@@ -281,7 +281,7 @@ class EventControllerTest {
     }
 
     @Test
-    @DisplayName("Member가 생성한 Event 최신순으로 페이징 조회 성공 테스트 - (page = 1, size = 4, 이벤트상태 = 진행)")
+    @DisplayName("Member가 생성한 Event 최신순으로 페이징 조회 성공 테스트 - (page = 1, size = 2, 이벤트상태 = 진행)")
     void searchSimpleDescByMemberSuccessTest3() throws Exception {
         //given
         Member userMember = TestMemberFactory.getUserMember(entityManager);
@@ -320,6 +320,7 @@ class EventControllerTest {
                 .contentType(MediaType.APPLICATION_JSON)
                 .param("eventProgressStatus", EventProgressStatus.RUNNING.name())
                 .param("page", "1")
+                .param("size", "2")
         );
         //then
         result.andDo(print())
@@ -329,12 +330,14 @@ class EventControllerTest {
                 handler().methodName("searchSimpleDescByMember"),
                 jsonPath("$.success", is(true)),
                 jsonPath("$.error", is(nullValue())),
-                jsonPath("$.data.simpleEventList[0].eventId", is(runningEvent.getId().intValue())),
-                jsonPath("$.data.pagination.totalPages", is(2)),
+                jsonPath("$.data.simpleEventList.length()", is(2)),
+                jsonPath("$.data.simpleEventList[*].eventId",
+                    contains(runningEvent3.getId().intValue(), runningEvent2.getId().intValue())),
+                jsonPath("$.data.pagination.totalPages", is(3)),
                 jsonPath("$.data.pagination.totalElements", is(5)),
                 jsonPath("$.data.pagination.currentPage", is(1)),
-                jsonPath("$.data.pagination.offset", is(4)),
-                jsonPath("$.data.pagination.size", is(4))
+                jsonPath("$.data.pagination.offset", is(2)),
+                jsonPath("$.data.pagination.size", is(2))
             );
     }
 

--- a/src/test/java/com/dokev/gold_dduck/event/controller/EventControllerTest.java
+++ b/src/test/java/com/dokev/gold_dduck/event/controller/EventControllerTest.java
@@ -1,5 +1,7 @@
 package com.dokev.gold_dduck.event.controller;
 
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.matchesPattern;
@@ -8,6 +10,7 @@ import static org.hamcrest.Matchers.nullValue;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.handler;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -15,6 +18,7 @@ import com.dokev.gold_dduck.common.error.ErrorCode;
 import com.dokev.gold_dduck.event.converter.EventFindConverter;
 import com.dokev.gold_dduck.event.converter.EventSaveConverter;
 import com.dokev.gold_dduck.event.domain.Event;
+import com.dokev.gold_dduck.event.domain.EventProgressStatus;
 import com.dokev.gold_dduck.event.dto.EventDto;
 import com.dokev.gold_dduck.event.dto.EventSaveDto;
 import com.dokev.gold_dduck.factory.TestEventFactory;
@@ -191,4 +195,170 @@ class EventControllerTest {
             .andExpect(jsonPath("$.error.message",
                 containsString("해당 엔티티를 찾을 수 없습니다.")));
     }
+
+    @Test
+    @DisplayName("Member가 생성한 Event 최신순으로 페이징 조회 성공 테스트 - (page = 0, size = 4, 이벤트상태 = 전체)")
+    void searchSimpleDescByMemberSuccessTest() throws Exception {
+        //given
+        Member userMember = TestMemberFactory.getUserMember(entityManager);
+        Event closedEvent = TestEventFactory.builder(userMember)
+            .eventProgressStatus(EventProgressStatus.CLOSED)
+            .build();
+        Event runningEvent = TestEventFactory.builder(userMember)
+            .eventProgressStatus(EventProgressStatus.RUNNING)
+            .build();
+        Event readyEvent = TestEventFactory.builder(userMember)
+            .eventProgressStatus(EventProgressStatus.READY)
+            .build();
+        entityManager.persist(closedEvent);
+        entityManager.persist(runningEvent);
+        entityManager.persist(readyEvent);
+        //when
+        ResultActions result = mockMvc.perform(
+            get("/api/v1/members/{memberId}/events", userMember.getId())
+                .accept(MediaType.APPLICATION_JSON)
+                .contentType(MediaType.APPLICATION_JSON)
+        );
+        //then
+        result.andDo(print())
+            .andExpectAll(
+                status().isOk(),
+                handler().handlerType(EventController.class),
+                handler().methodName("searchSimpleDescByMember"),
+                jsonPath("$.success", is(true)),
+                jsonPath("$.error", is(nullValue())),
+                jsonPath("$.data..eventId",
+                    containsInAnyOrder(closedEvent.getId().intValue(),
+                        runningEvent.getId().intValue(),
+                        readyEvent.getId().intValue())),
+                jsonPath("$.data.pagination.totalPages", is(1)),
+                jsonPath("$.data.pagination.totalElements", is(3)),
+                jsonPath("$.data.pagination.currentPage", is(0)),
+                jsonPath("$.data.pagination.offset", is(0)),
+                jsonPath("$.data.pagination.size", is(4))
+            );
+    }
+
+    @Test
+    @DisplayName("Member가 생성한 Event 최신순으로 페이징 조회 성공 테스트 - (page = 0, size = 4, 이벤트상태 = 완료)")
+    void searchSimpleDescByMemberSuccessTest2() throws Exception {
+        //given
+        Member userMember = TestMemberFactory.getUserMember(entityManager);
+        Event closedEvent = TestEventFactory.builder(userMember)
+            .eventProgressStatus(EventProgressStatus.CLOSED)
+            .build();
+        Event runningEvent = TestEventFactory.builder(userMember)
+            .eventProgressStatus(EventProgressStatus.RUNNING)
+            .build();
+        Event readyEvent = TestEventFactory.builder(userMember)
+            .eventProgressStatus(EventProgressStatus.READY)
+            .build();
+        entityManager.persist(closedEvent);
+        entityManager.persist(runningEvent);
+        entityManager.persist(readyEvent);
+        //when
+        ResultActions result = mockMvc.perform(
+            get("/api/v1/members/{memberId}/events", userMember.getId())
+                .accept(MediaType.APPLICATION_JSON)
+                .contentType(MediaType.APPLICATION_JSON)
+                .param("eventProgressStatus", EventProgressStatus.CLOSED.name())
+        );
+        //then
+        result.andDo(print())
+            .andExpectAll(
+                status().isOk(),
+                handler().handlerType(EventController.class),
+                handler().methodName("searchSimpleDescByMember"),
+                jsonPath("$.success", is(true)),
+                jsonPath("$.error", is(nullValue())),
+                jsonPath("$.data..eventId", contains(closedEvent.getId().intValue())),
+                jsonPath("$.data.pagination.totalPages", is(1)),
+                jsonPath("$.data.pagination.totalElements", is(1)),
+                jsonPath("$.data.pagination.currentPage", is(0)),
+                jsonPath("$.data.pagination.offset", is(0)),
+                jsonPath("$.data.pagination.size", is(4))
+            );
+    }
+
+    @Test
+    @DisplayName("Member가 생성한 Event 최신순으로 페이징 조회 성공 테스트 - (page = 1, size = 4, 이벤트상태 = 진행)")
+    void searchSimpleDescByMemberSuccessTest3() throws Exception {
+        //given
+        Member userMember = TestMemberFactory.getUserMember(entityManager);
+        Event closedEvent = TestEventFactory.builder(userMember)
+            .eventProgressStatus(EventProgressStatus.CLOSED)
+            .build();
+        Event runningEvent = TestEventFactory.builder(userMember)
+            .eventProgressStatus(EventProgressStatus.RUNNING)
+            .build();
+        Event runningEvent2 = TestEventFactory.builder(userMember)
+            .eventProgressStatus(EventProgressStatus.RUNNING)
+            .build();
+        Event runningEvent3 = TestEventFactory.builder(userMember)
+            .eventProgressStatus(EventProgressStatus.RUNNING)
+            .build();
+        Event runningEvent4 = TestEventFactory.builder(userMember)
+            .eventProgressStatus(EventProgressStatus.RUNNING)
+            .build();
+        Event runningEvent5 = TestEventFactory.builder(userMember)
+            .eventProgressStatus(EventProgressStatus.RUNNING)
+            .build();
+        Event readyEvent = TestEventFactory.builder(userMember)
+            .eventProgressStatus(EventProgressStatus.READY)
+            .build();
+        entityManager.persist(closedEvent);
+        entityManager.persist(runningEvent);
+        entityManager.persist(runningEvent2);
+        entityManager.persist(runningEvent3);
+        entityManager.persist(runningEvent4);
+        entityManager.persist(runningEvent5);
+        entityManager.persist(readyEvent);
+        //when
+        ResultActions result = mockMvc.perform(
+            get("/api/v1/members/{memberId}/events", userMember.getId())
+                .accept(MediaType.APPLICATION_JSON)
+                .contentType(MediaType.APPLICATION_JSON)
+                .param("eventProgressStatus", EventProgressStatus.RUNNING.name())
+                .param("page", "1")
+        );
+        //then
+        result.andDo(print())
+            .andExpectAll(
+                status().isOk(),
+                handler().handlerType(EventController.class),
+                handler().methodName("searchSimpleDescByMember"),
+                jsonPath("$.success", is(true)),
+                jsonPath("$.error", is(nullValue())),
+                jsonPath("$.data.simpleEventList[0].eventId", is(runningEvent.getId().intValue())),
+                jsonPath("$.data.pagination.totalPages", is(2)),
+                jsonPath("$.data.pagination.totalElements", is(5)),
+                jsonPath("$.data.pagination.currentPage", is(1)),
+                jsonPath("$.data.pagination.offset", is(4)),
+                jsonPath("$.data.pagination.size", is(4))
+            );
+    }
+
+    @Test
+    @DisplayName("Member가 생성한 Event 최신순으로 페이징 조회 실패 테스트 - (잘못된 memberId)")
+    void searchSimpleDescByMemberFailureTest() throws Exception {
+        //given
+        Long invalidMemberId = -1L;
+        //when
+        ResultActions result = mockMvc.perform(
+            get("/api/v1/members/{memberId}/events", invalidMemberId)
+                .accept(MediaType.APPLICATION_JSON)
+                .contentType(MediaType.APPLICATION_JSON)
+        );
+        //then
+        result.andDo(print())
+            .andExpectAll(
+                status().is4xxClientError(),
+                handler().handlerType(EventController.class),
+                handler().methodName("searchSimpleDescByMember"),
+                jsonPath("$.success", is(false)),
+                jsonPath("$.error.code", is(ErrorCode.ENTITY_NOT_FOUND.getCode())),
+                jsonPath("$.error.message", containsString(Member.class.getName()))
+            );
+    }
+
 }


### PR DESCRIPTION
## 📌 이슈 설명 <!-- 어떤 걸 만들었는지 대략적으로 설명해주세요 -->
[GD-43](https://maenguin.atlassian.net/browse/GD-43)
## ✅ PR 포인트 & 궁금한 점 <!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->
**멤버의 이벤트 조회 API 추가 했습니다**
* 이벤트 상태로 필터링을 적용시키기 위해서 queryDSL을 추가했습니다 (pull 받으시면 clean 후 build를 꼭 해주세요)
* 이벤트를 최신순으로 페이징해서 가져올 수 있도록 구현했습니다.
* 조회하는 Event는 EventSImpleDto로 단순하게 이벤트만 조회하도록 했습니다(조인 x)
* 서비스와 컨트롤러를 같이 구현했습니다
* 서비스 테스트는 제외하는 대신 컨트롤러 테스트에 집중했습니다