### PR TITLE
[GD-154] refactor : log4j 버전 업데이트

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -43,6 +43,8 @@ dependencies {
     implementation 'io.springfox:springfox-boot-starter:3.0.0'
     testImplementation 'org.springframework.security:spring-security-test'
     implementation 'com.querydsl:querydsl-jpa'
+    implementation group: 'org.apache.logging.log4j', name: 'log4j-api', version: '2.15.0'
+    implementation group: 'org.apache.logging.log4j', name: 'log4j-to-slf4j', version: '2.15.0'
 }
 
 test {


### PR DESCRIPTION
## 📌 이슈 설명 <!-- 어떤 걸 만들었는지 대략적으로 설명해주세요 -->
- [GD-154](https://maenguin.atlassian.net/browse/GD-154)

## ✅ PR 포인트 & 궁금한 점 <!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->

log4j 버전 ~2.14 까지 보안 이슈가 크게 있는거 같아서 기본적으로 의존 되어서 들어오는 log4j 버전 보니까 2.14.1이라서 2.15로 버전 명시했습니다.

- [KISA 인터넷 보호나라&KrCERT](https://www.krcert.or.kr/data/secNoticeView.do?bulletin_writing_sequence=36389)
- [Apache Releases Log4j Version 2.15.0 to Address Critical RCE Vulnerability Under Exploitation](https://www.cisa.gov/uscert/ncas/current-activity/2021/12/10/apache-releases-log4j-version-2150-address-critical-rce)
