### PR TITLE
[GD-183] fix : 이벤트 생성 시 데이터 바인딩 실패 오류 수정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -43,8 +43,8 @@ dependencies {
     implementation 'io.springfox:springfox-boot-starter:3.0.0'
     testImplementation 'org.springframework.security:spring-security-test'
     implementation 'com.querydsl:querydsl-jpa'
-    implementation group: 'org.apache.logging.log4j', name: 'log4j-api', version: '2.15.0'
-    implementation group: 'org.apache.logging.log4j', name: 'log4j-to-slf4j', version: '2.15.0'
+    implementation group: 'org.apache.logging.log4j', name: 'log4j-api', version: '2.16.0'
+    implementation group: 'org.apache.logging.log4j', name: 'log4j-to-slf4j', version: '2.16.0'
 }
 
 test {

--- a/src/main/java/com/dokev/gold_dduck/event/converter/EventSaveConverter.java
+++ b/src/main/java/com/dokev/gold_dduck/event/converter/EventSaveConverter.java
@@ -80,7 +80,7 @@ public class EventSaveConverter {
     }
 
     public GiftSaveDto convertToGiftSaveDto(Gift gift) {
-        return new GiftSaveDto(gift.getCategory(), convertToGiftItemDtos(gift.getGiftItems()), UUID.randomUUID());
+        return new GiftSaveDto(gift.getCategory(), convertToGiftItemDtos(gift.getGiftItems()));
     }
 
     public List<GiftItemSaveDto> convertToGiftItemDtos(List<GiftItem> giftItems) {

--- a/src/main/java/com/dokev/gold_dduck/event/dto/EventSaveDto.java
+++ b/src/main/java/com/dokev/gold_dduck/event/dto/EventSaveDto.java
@@ -11,9 +11,11 @@ import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.format.annotation.DateTimeFormat.ISO;
 
+@Setter
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor

--- a/src/main/java/com/dokev/gold_dduck/event/dto/GiftItemSaveDto.java
+++ b/src/main/java/com/dokev/gold_dduck/event/dto/GiftItemSaveDto.java
@@ -6,8 +6,10 @@ import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 import org.springframework.web.multipart.MultipartFile;
 
+@Setter
 @Getter
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)

--- a/src/main/java/com/dokev/gold_dduck/event/dto/GiftSaveDto.java
+++ b/src/main/java/com/dokev/gold_dduck/event/dto/GiftSaveDto.java
@@ -1,14 +1,15 @@
 package com.dokev.gold_dduck.event.dto;
 
 import java.util.List;
-import java.util.UUID;
 import javax.validation.constraints.NotEmpty;
 import javax.validation.constraints.NotNull;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 
+@Setter
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
@@ -21,5 +22,4 @@ public class GiftSaveDto {
     @NotEmpty
     private List<GiftItemSaveDto> giftItems;
 
-    private UUID giftCheckId;
 }

--- a/src/test/java/com/dokev/gold_dduck/factory/TestEventFactory.java
+++ b/src/test/java/com/dokev/gold_dduck/factory/TestEventFactory.java
@@ -94,7 +94,7 @@ public class TestEventFactory {
         giftItemSaveDtos.add(giftItemSaveDto2);
         giftItemSaveDtos.add(giftItemSaveDto3);
 
-        GiftSaveDto giftSaveDto = new GiftSaveDto("gift1", giftItemSaveDtos, UUID.randomUUID());
+        GiftSaveDto giftSaveDto = new GiftSaveDto("gift1", giftItemSaveDtos);
 
         giftSaveDtos.add(giftSaveDto);
 


### PR DESCRIPTION
## 📌 이슈 설명 <!-- 어떤 걸 만들었는지 대략적으로 설명해주세요 -->
- [GD-183](https://maenguin.atlassian.net/browse/GD-183)

## ✅ PR 포인트 & 궁금한 점 <!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->

- 예전 pr에서 말씀드렸던거와 달리 `@ModelAttribute` 사용 시 적당한 생성자를 사용하고 없으면 Setter를 통해서 필드에 대한 값들을 주입해준다고 합니다. 그래서 Setter가 없을 경우 제대로 데이터 바인딩이 안돼서 오류가 납니다.
- 롬복 생성자를 제거하고 직접 생성자를 만들어도 제대로 값을 바인딩하지 못하는것을 확인해서 Setter를 사용하게 되었습니다.
  - 참고 : https://mangkyu.tistory.com/72

- Setter를 사용하지 않는 방법으로는 @ControllerAdvice에서 @initBinder로 필드에 직접 주입하도록 설정하면 되긴 하나, 이렇게 했을 경우 모든 컨트롤러에 영향이 갈수도 있을 것 같아서 이벤트 생성 시 사용하는 dto에 Setter를 사용하는게 나을 것이라고 판단했습니다.
  - 직접 주입 하는 방법 참고 : https://jojoldu.tistory.com/407

잘 모르고 pr을 올려서 잘못된 내용으로 혼란을 드려 죄송합니다 ㅠㅠ

## postman 성공
![image](https://user-images.githubusercontent.com/47075043/146269340-26e7c993-7c20-40de-afb1-e73fb3589788.png)
