### PR TITLE
[GD-227] feat : 선착순 동시성 문제 해결 및 버전 2 추가

### DIFF
--- a/src/main/java/com/dokev/gold_dduck/gift/controller/GiftController.java
+++ b/src/main/java/com/dokev/gold_dduck/gift/controller/GiftController.java
@@ -41,6 +41,13 @@ public class GiftController {
         return ApiResponse.success(giftItemDto);
     }
 
+    @PostMapping("/v2/gifts/fifo")
+    public ApiResponse<GiftItemDto> chooseGiftItemByFIFOV2(@RequestBody @Validated GiftFifoChoiceDto giftFifoChoiceDto) {
+        GiftItemDto giftItemDto = giftService.chooseGiftItemByFIFOV2(giftFifoChoiceDto.getEventId(),
+            giftFifoChoiceDto.getMemberId(), giftFifoChoiceDto.getGiftId());
+        return ApiResponse.success(giftItemDto);
+    }
+
     @PostMapping("/v1/gifts/random")
     public ApiResponse<GiftItemDetailDto> chooseGiftItemByRandom(
         @RequestBody @Valid GiftRandomChoiceDto giftRandomChoiceDto

--- a/src/main/java/com/dokev/gold_dduck/gift/repository/GiftItemRepository.java
+++ b/src/main/java/com/dokev/gold_dduck/gift/repository/GiftItemRepository.java
@@ -13,10 +13,9 @@ import org.springframework.data.repository.query.Param;
 
 public interface GiftItemRepository extends JpaRepository<GiftItem, Long> {
 
-    @Lock(LockModeType.PESSIMISTIC_WRITE)
     @Query("select gl from GiftItem gl"
         + " where gl.gift.id = :giftId and gl.member is null")
-    List<GiftItem> findByGiftIdWithPageForUpdate(@Param("giftId") Long giftId, Pageable pageable);
+    List<GiftItem> findByGiftIdWithPage(@Param("giftId") Long giftId, Pageable pageable);
 
     @Modifying
     @Query("update GiftItem gi"


### PR DESCRIPTION
## 📌 이슈 설명 <!-- 어떤 걸 만들었는지 대략적으로 설명해주세요 -->
[GD-227](https://maenguin.atlassian.net/browse/GD-227)
## ✅ PR 포인트 & 궁금한 점 <!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->
저번에 이벤트 종료 조건 추가하면서
선착순 수행시 락이 제대로 안걸려서 결과가 잘못나오게 되었는데 이를 수정했습니다

거기에 지금 선착순이 눈치게임 방식인데 원래 선착순 방식인 버전 2를 추가했습니다.